### PR TITLE
CI: setup pnpm robuste (corepack + fallback)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,28 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
-      - name: Setup pnpm
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup pnpm (action)
         uses: pnpm/action-setup@v3
         with:
           version: 9
-          run_install: true
+          run_install: false
+
+      - name: Verify pnpm & fallback
+        shell: bash
+        run: |
+          set -e
+          echo "PATH=$PATH"
+          if ! command -v pnpm >/dev/null 2>&1; then
+            echo "pnpm not found after action, installing via npm ..."
+            npm install -g pnpm@9
+          fi
+          pnpm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma Client
         run: pnpm db:generate
@@ -68,4 +85,3 @@ jobs:
             e2e-artifacts/**
             test-results/**
           if-no-files-found: ignore
-


### PR DESCRIPTION
Description: Renforce l’installation pnpm dans la CI pour éliminer les échecs intermittents (command not found / cache incohérent).
Changements:
Ajout corepack enable avant usage.
Action pnpm/action-setup@v3 (version 9) sans installation auto.
Étape de vérification + fallback (installation globale via npm si pnpm absent).
Utilisation de pnpm install --frozen-lockfile.
Ordre des étapes clarifié (install → prisma → lint → typecheck → tests → build → e2e).
Motivation: Éviter les échecs liés à pnpm non disponible ou au cache partiel sur runners GitHub.
Validation attendue:
Étape "Verify pnpm & fallback" affiche une version 9.x.
Installation rapide si cache pnpm présent.
Lint, typecheck, tests unitaires et e2e passent.

Aucune modification applicative. Uniquement CI.