### PR TITLE
P4-A: Moteur de mapping PCG (config JSON + agrégats)

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,15 +1,5 @@
-# Connexion directe (pour migrations / prisma migrate dev)
-DIRECT_URL="postgresql://postgres.rnjxyimhtnumokusxmhb:77Eh5bwsrStswuQoRi@aws-1-eu-west-3.pooler.supabase.com:5432/postgres"
-# Connexion poolée (PgBouncer) pour l'exécution runtime
-DATABASE_URL=postgresql://postgres.rnjxyimhtnumokusxmhb:77Eh5bwsrStswuQoRi@aws-1-eu-west-3.pooler.supabase.com:6543/postgres?pgbouncer=true&sslmode=require
-
-NEXT_PUBLIC_SUPABASE_URL=https://rnjxyimhtnumokusxmhb.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJuanh5aW1odG51bW9rdXN4bWhiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUwODEyMTgsImV4cCI6MjA3MDY1NzIxOH0.haWsytUgDPg1obqXY6Yt8W718WMkbho2DJklG2V6VFE
-
-# (Optionnel) SERVICE ROLE jamais côté client
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJuanh5aW1odG51bW9rdXN4bWhiIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NTA4MTIxOCwiZXhwIjoyMDcwNjU3MjE4fQ.wRd5sgW_hriUwVzAzYLT__JnoFpGzWawY-MbA8efiN8
-
-ADMIN_SEED_EMAIL=admin@example.com
-ADMIN_SEED_PASSWORD=Test1234!
-ADMIN_SEED_NAME=Super_Admin
+NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-test-key
+DATABASE_URL=postgresql://user:pass@localhost:5432/db
+DIRECT_URL=postgresql://user:pass@localhost:5432/db
 

--- a/.env.local
+++ b/.env.local
@@ -1,5 +1,0 @@
-NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
-NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-test-key
-DATABASE_URL=postgresql://user:pass@localhost:5432/db
-DIRECT_URL=postgresql://user:pass@localhost:5432/db
-

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-test-key
+DATABASE_URL=postgresql://user:pass@localhost:5432/db
+DIRECT_URL=postgresql://user:pass@localhost:5432/db
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Stack: Next 15 • React 19 • TypeScript (strict) • Tailwind v4 (CLI) • Ma
 ## Scripts principaux
 - `pnpm dev` (Turbopack + Tailwind CLI watch)
 - `pnpm build`
+- `pnpm preview` (prévisualisation prod intelligente: rebuild seulement si nécessaire)
+- `pnpm preview:fast` (démarre directement `next start` en supposant la build à jour)
 - `pnpm css:dev` / `pnpm css:build`
 - `pnpm db:generate` / `pnpm db:migrate` / `pnpm db:push` / `pnpm db:studio` / `pnpm db:format`
 - `pnpm db:seed:demo` (seed démo propriétés + immobilisations + écritures journal)

--- a/README.md
+++ b/README.md
@@ -157,3 +157,30 @@ pnpm test:e2e
 
 ---
 RLS: exécuter `supabase/policies.sql` après création des tables (si non gérées via l'interface).
+
+## Extension Mapping PCG -> Rubriques (2033C)
+Le moteur de mapping (P4-A) lit `config/config-pcg.json` (liste d'objets):
+```json
+{
+  "account_prefix": "706",
+  "rubrique": "CA",
+  "form": "2033C",
+  "label": "Chiffre d’affaires"
+}
+```
+Règles:
+- `account_prefix`: préfixe de compte (priorité au plus long si chevauchement: ex. `615` avant `61` ou `6`).
+- `rubrique`: identifiant fonctionnel (ex: `ChargesExternes`, `CA`).
+- `form`: code formulaire cible (actuellement `2033C`).
+- `label`: libellé lisible.
+
+L'utilitaire `mapToRubriques` agrège une liste d'écritures (type achat=Débit / vente=Crédit) en montants par rubrique (+ dataset amortissements `6811*`).
+
+Ajouter un nouveau mapping:
+1. Insérer une nouvelle ligne JSON dans `config/config-pcg.json` (respecter le tri optionnel par granularité si souhaité).
+2. (Optionnel) Ajouter un test ciblé dans `src/lib/accounting/mapToRubriques.test.ts`.
+3. Lancer `pnpm test`.
+
+Comptes non mappés: ignorés silencieusement (extensible ultérieurement: warning ou fallback). Pour étendre à d'autres formulaires (2033A, 2033E), ajouter des règles avec `form` différent puis filtrer côté service/API.
+
+Résultat courant: helper `computeResultatCourant(rubriques)` calcule (Produits nets - Charges) où Produits nets = `CA` - `CA_Moins`.

--- a/config/config-pcg.json
+++ b/config/config-pcg.json
@@ -1,0 +1,12 @@
+[
+  { "account_prefix": "706",  "rubrique": "CA",                    "form": "2033C", "label": "Chiffre d’affaires" },
+  { "account_prefix": "709",  "rubrique": "CA_Moins",               "form": "2033C", "label": "Rabais / ristournes" },
+  { "account_prefix": "606",  "rubrique": "ChargesExternes",        "form": "2033C", "label": "Achats non stockés" },
+  { "account_prefix": "613",  "rubrique": "ChargesExternes",        "form": "2033C", "label": "Locations / charges" },
+  { "account_prefix": "615",  "rubrique": "ChargesExternes",        "form": "2033C", "label": "Entretien / maintenance" },
+  { "account_prefix": "616",  "rubrique": "Assurances",             "form": "2033C", "label": "Assurances" },
+  { "account_prefix": "62",   "rubrique": "ServicesExterieurs",     "form": "2033C", "label": "Services extérieurs (autres)" },
+  { "account_prefix": "635",  "rubrique": "ImpotsTaxes",            "form": "2033C", "label": "Impôts et taxes" },
+  { "account_prefix": "6811", "rubrique": "DotationsAmortissements", "form": "2033C", "label": "Dotations aux amortissements" }
+]
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,32 +1,7 @@
 import type { NextConfig } from "next";
+import { buildSecurityHeaders } from './src/lib/security-headers';
 
-const isProd = process.env.NODE_ENV === 'production';
-
-const csp = [
-  "default-src 'self'",
-  // Next / React peuvent nécessiter unsafe-eval en dev (source maps) => on le retire en prod
-  `script-src 'self' 'unsafe-inline' ${isProd ? '' : "'unsafe-eval'"} *.supabase.co`.trim(),
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob:",
-  "font-src 'self'",
-  "connect-src 'self' *.supabase.co",
-  "frame-ancestors 'none'",
-  "object-src 'none'",
-  "base-uri 'self'",
-  "form-action 'self'"
-].join('; ');
-
-const securityHeaders = [
-  { key: 'X-Frame-Options', value: 'DENY' },
-  { key: 'X-Content-Type-Options', value: 'nosniff' },
-  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
-  { key: 'X-XSS-Protection', value: '0' },
-  { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
-  { key: 'Cross-Origin-Resource-Policy', value: 'same-origin' },
-  ...(isProd ? [{ key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' }] : []),
-  { key: 'Content-Security-Policy', value: csp },
-];
+const securityHeaders = buildSecurityHeaders({ env: process.env.NODE_ENV || 'development', supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL });
 
 const nextConfig: NextConfig = {
   async headers() {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",
-    "preview:fast": "next start",
-    "preview": "node scripts/preview.js"
+    "test:unit":"dotenv -e .env.test -- vitest run"
   },
   "dependencies": {
     "@mantine/core": "^8.2.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "lint": "next lint",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "preview:fast": "next start",
+    "preview": "node scripts/preview.js"
   },
   "dependencies": {
     "@mantine/core": "^8.2.4",

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/*
+ * Script preview intelligent.
+ * Objectif: démarrer l'appli en production locale sans rebuild systématique.
+ * Règle:
+ *  - Si aucune build existante (.next/BUILD_ID absent) => build.
+ *  - Si FORCE_BUILD=1 => build forcée.
+ *  - Sinon on compare le mtime de la build au mtime le plus récent des sources clés (src, prisma/schema.prisma, config fichiers).
+ *  - Si une source est plus récente => rebuild, sinon start direct.
+ *
+ * Options env:
+ *  FORCE_BUILD=1       Force la reconstruction.
+ *  PREVIEW_VERBOSE=1   Log détaillé.
+ */
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = process.cwd();
+const verbose = process.env.PREVIEW_VERBOSE === '1';
+const force = process.env.FORCE_BUILD === '1';
+
+function log(msg) { console.log(msg); }
+function info(msg) { console.log(`\x1b[36m[i]\x1b[0m ${msg}`); }
+function warn(msg) { console.warn(`\x1b[33m[!]\x1b[0m ${msg}`); }
+function success(msg) { console.log(`\x1b[32m[✓]\x1b[0m ${msg}`); }
+function error(msg) { console.error(`\x1b[31m[✗]\x1b[0m ${msg}`); }
+
+function newestMtime(targetPath) {
+  let newest = 0;
+  if (!fs.existsSync(targetPath)) return newest;
+  const stat = fs.statSync(targetPath);
+  if (stat.isFile()) return stat.mtimeMs;
+  // directory walk (shallow-ish for speed)
+  const entries = fs.readdirSync(targetPath);
+  for (const e of entries) {
+    const p = path.join(targetPath, e);
+    try {
+      const s = fs.statSync(p);
+      if (s.isDirectory()) {
+        // limit depth to 2 to avoid huge walk
+        const sub = fs.readdirSync(p).slice(0, 200);
+        for (const subE of sub) {
+          const sp = path.join(p, subE);
+          try { const ss = fs.statSync(sp); if (ss.mtimeMs > newest) newest = ss.mtimeMs; } catch {/* ignore */}
+        }
+      } else {
+        if (s.mtimeMs > newest) newest = s.mtimeMs;
+      }
+    } catch {/* ignore */}
+  }
+  return newest;
+}
+
+function collectSourcesMtime() {
+  const candidates = [
+    'src',
+    'prisma/schema.prisma',
+    'package.json',
+    'next.config.ts',
+    'tailwind.config.ts',
+    'eslint.config.mjs'
+  ];
+  let newest = 0;
+  for (const c of candidates) {
+    const p = path.join(root, c);
+    const m = newestMtime(p);
+    if (m > newest) newest = m;
+    if (verbose) info(`mtime ${c}: ${m || 'n/a'}`);
+  }
+  return newest;
+}
+
+function build() {
+  info('Lancement build (pnpm build)...');
+  const r = spawnSync('pnpm', ['build'], { stdio: 'inherit', shell: process.platform === 'win32' });
+  if (r.status !== 0) {
+    error('Build échouée');
+    process.exit(r.status || 1);
+  }
+  success('Build terminée');
+}
+
+function start() {
+  info('Démarrage (pnpm start)...');
+  const r = spawnSync('pnpm', ['start'], { stdio: 'inherit', shell: process.platform === 'win32' });
+  process.exit(r.status || 0);
+}
+
+(function main() {
+  const buildIdPath = path.join(root, '.next', 'BUILD_ID');
+  let needBuild = false;
+  if (force) {
+    info('FORCE_BUILD=1 -> rebuild forcé');
+    needBuild = true;
+  } else if (!fs.existsSync(buildIdPath)) {
+    info('Pas de build existante détectée');
+    needBuild = true;
+  } else {
+    const buildStat = fs.statSync(buildIdPath);
+    const buildMtime = buildStat.mtimeMs;
+    const sourcesMtime = collectSourcesMtime();
+    if (verbose) info(`mtime build: ${buildMtime}`);
+    if (sourcesMtime > buildMtime) {
+      info('Sources plus récentes que la build');
+      needBuild = true;
+    } else {
+      success('Build à jour (aucune reconstruction)');
+    }
+  }
+  if (needBuild) build();
+  start();
+})();
+

--- a/src/app/api/reports/ledger/export/route.ts
+++ b/src/app/api/reports/ledger/export/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { generateLedgerPdf } from '@/lib/ledger-pdf';
+import { computeLedger } from '@/lib/ledger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type SQLValue = string | number | Date;
+interface RawRow { id: string; date: Date; designation: string; tier: string | null; type: 'achat' | 'vente'; amount: unknown; }
+
+function parseNum(n: unknown): number { if (typeof n === 'number') return n; if (typeof n === 'string') { const v = parseFloat(n); return isNaN(v)?0:v; } if (n && typeof n === 'object' && 'toString' in n) { const v = parseFloat((n as { toString(): string }).toString()); return isNaN(v)?0:v; } return 0; }
+
+interface BaseRow { date: string; designation: string; tier: string; debit: number; credit: number; }
+
+async function fetchLedger(userId: string, account_code: string, params: { from?: string|null; to?: string|null; q?: string|null }): Promise<BaseRow[]> {
+  const { from, to, q } = params;
+  const whereParts = ['user_id = $1', 'account_code = $2'];
+  const values: SQLValue[] = [userId, account_code];
+  let idx = 3;
+  if (from) { whereParts.push(`date >= $${idx++}`); values.push(new Date(from)); }
+  if (to) { whereParts.push(`date <= $${idx++}`); values.push(new Date(to)); }
+  if (q) { whereParts.push(`(designation ILIKE $${idx} OR tier ILIKE $${idx})`); values.push('%'+q+'%'); idx++; }
+  const sql = `SELECT id, date, designation, tier, type, amount FROM journal_entries WHERE ${whereParts.join(' AND ')} ORDER BY date, created_at, id`;
+  const rows = await prisma.$queryRawUnsafe<RawRow[]>(sql, ...values);
+  return rows.map(r => ({
+    date: r.date.toISOString(),
+    designation: r.designation,
+    tier: r.tier ?? '',
+    debit: r.type === 'achat' ? parseNum(r.amount) : 0,
+    credit: r.type === 'vente' ? parseNum(r.amount) : 0,
+  }));
+}
+
+export async function GET(req: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return new Response('Unauthorized', { status: 401 });
+  try { assertAdmin(user); } catch { return new Response('Forbidden', { status: 403 }); }
+
+  const { searchParams } = new URL(req.url);
+  const account_code = searchParams.get('account_code');
+  if (!account_code) return new Response('account_code requis', { status: 400 });
+  const format = (searchParams.get('format') === 'pdf') ? 'pdf' : 'csv';
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  const q = searchParams.get('q');
+
+  const baseRows = await fetchLedger(user.id, account_code, { from, to, q });
+  const ledgerLines = computeLedger(baseRows.map(r => ({
+    date: r.date,
+    account_code,
+    designation: r.designation,
+    debit: r.debit,
+    credit: r.credit,
+  })));
+  // Conserver l'info tier pour CSV
+  const ledgerWithTier = ledgerLines.map((l, i) => ({ ...l, tier: baseRows[i]?.tier || '' }));
+
+  if (format === 'csv') {
+    const header = 'date;designation;tier;debit;credit;balance\n';
+    const body = ledgerWithTier.map(l => [
+      l.date.slice(0,10),
+      l.designation.replace(/;/g, ','),
+      l.tier.replace(/;/g, ','),
+      l.debit ? l.debit.toFixed(2) : '',
+      l.credit ? l.credit.toFixed(2) : '',
+      l.balance.toFixed(2)
+    ].join(';')).join('\n');
+    return new Response(header + body + (body?'\n':''), { headers: { 'Content-Type': 'text/csv; charset=utf-8', 'Content-Disposition': `attachment; filename=ledger_${account_code}.csv` }});
+  }
+  const MAX = 5000;
+  const truncated = ledgerLines.length > MAX;
+  const pdfBuf = await generateLedgerPdf({ account_code, rows: truncated ? ledgerLines.slice(0, MAX) : ledgerLines, period: { from, to }, filters: { q } });
+  return new Response(new Uint8Array(pdfBuf), { headers: { 'Content-Type': 'application/pdf', 'Content-Disposition': `attachment; filename=ledger_${account_code}.pdf`, ...(truncated ? { 'X-Truncated': 'true' } : {}) }});
+}

--- a/src/app/reports/ledger/page.tsx
+++ b/src/app/reports/ledger/page.tsx
@@ -1,0 +1,113 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import Link from 'next/link';
+
+export const dynamic = 'force-dynamic';
+
+type SQLValue = string | number | Date;
+interface RawRow { id: string; date: Date; designation: string; tier: string | null; type: 'achat' | 'vente'; amount: unknown; }
+function parseNum(n: unknown): number { if (typeof n === 'number') return n; if (typeof n === 'string') { const v = parseFloat(n); return isNaN(v)?0:v; } if (n && typeof n === 'object' && 'toString' in n) { const v = parseFloat((n as { toString(): string }).toString()); return isNaN(v)?0:v; } return 0; }
+
+async function fetchLedger(userId: string, account_code: string, params: { from?: string|null; to?: string|null; q?: string|null }) {
+  const { from, to, q } = params;
+  const whereParts = ['user_id = $1', 'account_code = $2'];
+  const values: SQLValue[] = [userId, account_code];
+  let idx = 3;
+  if (from) { whereParts.push(`date >= $${idx++}`); values.push(new Date(from)); }
+  if (to) { whereParts.push(`date <= $${idx++}`); values.push(new Date(to)); }
+  if (q) { whereParts.push(`(designation ILIKE $${idx} OR tier ILIKE $${idx})`); values.push('%'+q+'%'); idx++; }
+  const sql = `SELECT id, date, designation, tier, type, amount FROM journal_entries WHERE ${whereParts.join(' AND ')} ORDER BY date, created_at, id`;
+  const rows = await prisma.$queryRawUnsafe<RawRow[]>(sql, ...values);
+  return rows.map(r => ({
+    id: r.id,
+    date: r.date.toISOString(),
+    designation: r.designation,
+    tier: r.tier ?? '',
+    debit: r.type === 'achat' ? parseNum(r.amount) : 0,
+    credit: r.type === 'vente' ? parseNum(r.amount) : 0,
+  }));
+}
+
+export default async function LedgerPage({ searchParams }: { searchParams: Promise<Record<string,string|string[]|undefined>> }) {
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return <div className="p-8">Non authentifié</div>;
+  try { assertAdmin(user); } catch { return <div className="p-8">Accès administrateur requis</div>; }
+  const sp = await searchParams;
+  const account_code = sp.account_code as string | undefined;
+  const from = sp.from as string | undefined;
+  const to = sp.to as string | undefined;
+  const q = sp.q as string | undefined;
+  if (!account_code) return <div className="p-8 space-y-4"><h1 className="text-xl font-semibold">Grand livre</h1><p className="text-sm text-muted-foreground">Paramètre account_code requis. Retour à la <Link href="/reports/balance" className="underline">Balance</Link>.</p></div>;
+
+  const rows = await fetchLedger(user.id, account_code, { from, to, q });
+  let running = 0;
+  const enriched = rows.map(r => { running += r.debit - r.credit; return { ...r, balance: running }; });
+  const totalDebit = enriched.reduce((a,r)=>a+r.debit,0);
+  const totalCredit = enriched.reduce((a,r)=>a+r.credit,0);
+
+  const hasFilter = !!(from||to||q);
+
+  return <main className="p-6 max-w-6xl mx-auto space-y-6">
+    <header className="flex flex-col gap-1">
+      <h1 className="text-2xl font-semibold tracking-tight">Grand livre – {account_code}</h1>
+      <p className="text-sm text-muted-foreground">{enriched.length} écritures • Débit {totalDebit.toFixed(2)} • Crédit {totalCredit.toFixed(2)} • Solde {(totalDebit-totalCredit).toFixed(2)}</p>
+      <p className="text-xs text-muted-foreground"><Link href="/reports/balance" className="underline">Retour Balance</Link></p>
+    </header>
+    <section className="card p-4 space-y-4 text-sm">
+      <form className="grid md:grid-cols-6 gap-3" method="get">
+        <input type="hidden" name="account_code" value={account_code} />
+        <input type="date" name="from" defaultValue={from||''} className="input" />
+        <input type="date" name="to" defaultValue={to||''} className="input" />
+        <input name="q" placeholder="Recherche texte" defaultValue={q||''} className="input md:col-span-2" />
+        <div className="flex items-center gap-2 md:col-span-1">
+          <button className="btn-primary">Filtrer</button>
+          {hasFilter && <a href={`/reports/ledger?account_code=${encodeURIComponent(account_code)}`} className="text-xs underline">Reset</a>}
+        </div>
+        <div className="md:col-span-6 flex flex-wrap gap-4 mt-2 text-xs text-muted-foreground">
+          {from && <span>Période: {from} → {to||'…'}</span>}
+          {hasFilter && <span className="px-2 py-0.5 bg-gray-200 rounded">Filtre actif</span>}
+        </div>
+      </form>
+      <div className="flex gap-2">
+        <a className="btn text-xs" href={`/api/reports/ledger/export?format=csv&account_code=${encodeURIComponent(account_code)}${from?`&from=${from}`:''}${to?`&to=${to}`:''}${q?`&q=${q}`:''}`}>Export CSV</a>
+        <a className="btn text-xs" href={`/api/reports/ledger/export?format=pdf&account_code=${encodeURIComponent(account_code)}${from?`&from=${from}`:''}${to?`&to=${to}`:''}${q?`&q=${q}`:''}`}>Export PDF</a>
+      </div>
+    </section>
+    <div className="card p-4 overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left border-b">
+            <th className="py-2 pr-4">Date</th>
+            <th className="py-2 pr-4">Tier</th>
+            <th className="py-2 pr-4">Désignation</th>
+            <th className="py-2 pr-4 text-right">Débit</th>
+            <th className="py-2 pr-4 text-right">Crédit</th>
+            <th className="py-2 pr-4 text-right">Solde</th>
+          </tr>
+        </thead>
+        <tbody>
+          {enriched.map(r => <tr key={r.id} className="border-b last:border-none hover:bg-gray-50">
+            <td className="py-1 pr-4 whitespace-nowrap">{r.date.slice(0,10)}</td>
+            <td className="py-1 pr-4">{r.tier}</td>
+            <td className="py-1 pr-4 font-medium">{r.designation}</td>
+            <td className="py-1 pr-4 text-right tabular-nums">{r.debit ? r.debit.toFixed(2) : ''}</td>
+            <td className="py-1 pr-4 text-right tabular-nums">{r.credit ? r.credit.toFixed(2) : ''}</td>
+            <td className="py-1 pr-4 text-right tabular-nums">{r.balance.toFixed(2)}</td>
+          </tr>)}
+          {!enriched.length && <tr><td colSpan={6} className="py-6 text-center text-muted-foreground">Aucune écriture</td></tr>}
+        </tbody>
+        <tfoot>
+          <tr className="font-semibold">
+            <td className="py-2 pr-4" colSpan={3}>Totaux</td>
+            <td className="py-2 pr-4 text-right">{totalDebit.toFixed(2)}</td>
+            <td className="py-2 pr-4 text-right">{totalCredit.toFixed(2)}</td>
+            <td className="py-2 pr-4 text-right">{(totalDebit-totalCredit).toFixed(2)}</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </main>;
+}
+

--- a/src/lib/accounting/mapToRubriques.test.ts
+++ b/src/lib/accounting/mapToRubriques.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { mapToRubriques, computeResultatCourant, JournalLikeEntry } from './mapToRubriques';
+
+function entry(partial: Partial<JournalLikeEntry>): JournalLikeEntry {
+  return {
+    type: 'achat',
+    account_code: '000',
+    amount: 0,
+    date: '2025-01-01',
+    ...partial
+  };
+}
+
+describe('mapToRubriques', () => {
+  it('agrège ventes 706 en crédit CA et rabais 709 en débit CA_Moins', () => {
+    const { rubriques } = mapToRubriques([
+      entry({ type: 'vente', account_code: '706', amount: 100 }),
+      entry({ type: 'vente', account_code: '7061', amount: 50 }), // même rubrique via prefix
+      entry({ type: 'achat', account_code: '709', amount: 10 }), // rabais => débit CA_Moins
+    ]);
+    const ca = rubriques.find(r=> r.rubrique==='CA');
+    const rabais = rubriques.find(r=> r.rubrique==='CA_Moins');
+    expect(ca?.total_credit).toBe(150); // 100 + 50
+    expect(ca?.total_debit).toBe(0);
+    expect(rabais?.total_debit).toBe(10);
+  });
+
+  it('priorité au préfixe le plus long (615 ne doit pas matcher règle générique 62)', () => {
+    const { rubriques } = mapToRubriques([
+      entry({ type: 'achat', account_code: '615', amount: 40 }),
+      entry({ type: 'achat', account_code: '620', amount: 20 }), // tombera dans ServicesExterieurs (62)
+    ]);
+    const chargesExt = rubriques.find(r=> r.rubrique==='ChargesExternes');
+    const services = rubriques.find(r=> r.rubrique==='ServicesExterieurs');
+    expect(chargesExt?.total_debit).toBe(40);
+    expect(services?.total_debit).toBe(20);
+  });
+
+  it('gère plusieurs rubriques de charges (606, 615, 616, 635) + dotations 6811', () => {
+    const { rubriques, amortizations } = mapToRubriques([
+      entry({ type: 'achat', account_code: '606', amount: 30 }),
+      entry({ type: 'achat', account_code: '615', amount: 15.555 }),
+      entry({ type: 'achat', account_code: '616', amount: 8 }),
+      entry({ type: 'achat', account_code: '635', amount: 12 }),
+      entry({ type: 'achat', account_code: '6811', amount: 100 }),
+    ]);
+    const chExt = rubriques.find(r=> r.rubrique==='ChargesExternes');
+    const assurances = rubriques.find(r=> r.rubrique==='Assurances');
+    const impots = rubriques.find(r=> r.rubrique==='ImpotsTaxes');
+    const dota = rubriques.find(r=> r.rubrique==='DotationsAmortissements');
+    expect(chExt?.total_debit).toBeCloseTo(45.56, 2); // 30 + 15.555 arrondi
+    expect(assurances?.total_debit).toBe(8);
+    expect(impots?.total_debit).toBe(12);
+    expect(dota?.total_debit).toBe(100);
+    expect(amortizations.length).toBe(1);
+    expect(amortizations[0].amount).toBe(100);
+  });
+
+  it('filtre période', () => {
+    const { rubriques } = mapToRubriques([
+      entry({ type: 'vente', account_code: '706', amount: 200, date: '2024-12-31' }),
+      entry({ type: 'vente', account_code: '706', amount: 300, date: '2025-01-01' }),
+    ], { from: new Date('2025-01-01'), to: new Date('2025-12-31') });
+    const ca = rubriques.find(r=> r.rubrique==='CA');
+    expect(ca?.total_credit).toBe(300); // exclut 2024-12-31
+  });
+
+  it('ignore montants NaN ou comptes non mappés', () => {
+    const { rubriques } = mapToRubriques([
+      entry({ type: 'vente', account_code: '999', amount: 500 }), // non mappé
+      entry({ type: 'achat', account_code: '606', amount: 'abc' as any }), // NaN
+      entry({ type: 'vente', account_code: '706', amount: 50 }),
+    ]);
+    expect(rubriques.find(r=> r.rubrique==='CA')?.total_credit).toBe(50);
+    expect(rubriques.find(r=> r.rubrique==='ChargesExternes')).toBeUndefined();
+  });
+});
+
+describe('computeResultatCourant', () => {
+  it('calcule Produits - Charges avec rabais', () => {
+    const { rubriques } = mapToRubriques([
+      entry({ type: 'vente', account_code: '706', amount: 100 }),
+      entry({ type: 'achat', account_code: '709', amount: 10 }), // rabais
+      entry({ type: 'achat', account_code: '606', amount: 30 }),
+      entry({ type: 'achat', account_code: '616', amount: 5 }),
+    ]);
+    const res = computeResultatCourant(rubriques);
+    // CA net = 100 - 10 = 90 ; Charges = 30 + 5 = 35 -> Résultat = 55
+    expect(res).toBe(55);
+  });
+});
+

--- a/src/lib/accounting/mapToRubriques.ts
+++ b/src/lib/accounting/mapToRubriques.ts
@@ -1,0 +1,103 @@
+// Moteur de mapping PCG -> Rubriques formulaires (2033C, etc.)
+// Chargé dynamiquement depuis config/config-pcg.json pour éviter le hard‑code.
+
+import mapping from '../../../config/config-pcg.json';
+
+
+export interface JournalLikeEntry {
+  type: 'achat' | 'vente';
+  account_code: string;
+  amount: number | string;
+  date: Date | string;
+}
+
+export interface RubriqueRule {
+  account_prefix: string; // ex: "706", "62"
+  rubrique: string;       // ex: "CA", "ChargesExternes"
+  form: string;           // ex: "2033C"
+  label: string;          // libellé humain
+}
+
+export interface RubriqueAggregate {
+  rubrique: string;
+  form: string;
+  label: string;
+  total_debit: number;   // somme montants où type=achat
+  total_credit: number;  // somme montants où type=vente
+  balance: number;       // aligné sur balance.ts => debit - credit
+}
+
+export interface MappingResult {
+  rubriques: RubriqueAggregate[]; // pour 2033C (et autres si on étend)
+  amortizations: { date: string; amount: number; account_code: string }[]; // sous-ensemble 6811 pour 2033E
+}
+
+// Pré-tri des règles: plus long préfixe d'abord pour priorité.
+const RULES: RubriqueRule[] = (mapping as RubriqueRule[]).slice().sort((a,b)=> b.account_prefix.length - a.account_prefix.length);
+
+function round2(n: number) { return Math.round(n * 100) / 100; }
+
+function matchRule(accountCode: string): RubriqueRule | undefined {
+  return RULES.find(r => accountCode.startsWith(r.account_prefix));
+}
+
+export interface PeriodFilter { from?: Date; to?: Date; }
+
+function inPeriod(d: Date, f?: PeriodFilter) {
+  if (!f) return true;
+  if (f.from && d < f.from) return false;
+  if (f.to && d > f.to) return false;
+  return true;
+}
+
+/**
+ * Agrège les écritures par rubrique selon la config.
+ * - Filtre période (inclusif) si fournie.
+ * - Ignore montants NaN ou comptes non mappés.
+ * - balance = total_debit - total_credit (cohérent avec balance.ts)
+ * - Fournit aussi la liste des dotations (rubrique DotationsAmortissements / compte 6811*) pour 2033E.
+ */
+export function mapToRubriques(entries: JournalLikeEntry[], period?: PeriodFilter): MappingResult {
+  const map = new Map<string, { rule: RubriqueRule; debit: number; credit: number }>();
+  const amortizations: { date: string; amount: number; account_code: string }[] = [];
+
+  for (const e of entries) {
+    if (!e || !e.account_code) continue;
+    const rule = matchRule(e.account_code);
+    if (!rule) continue; // pas de mapping => ignoré (extensible).
+    const d = new Date(e.date);
+    if (!inPeriod(d, period)) continue;
+    const amt = typeof e.amount === 'number' ? e.amount : parseFloat(e.amount);
+    if (isNaN(amt) || amt === 0) continue;
+    const rec = map.get(rule.rubrique) || { rule, debit: 0, credit: 0 };
+    if (e.type === 'achat') rec.debit += amt; else rec.credit += amt;
+    map.set(rule.rubrique, rec);
+    if (rule.rubrique === 'DotationsAmortissements') {
+      amortizations.push({ date: d.toISOString().slice(0,10), amount: round2(amt), account_code: e.account_code });
+    }
+  }
+
+  const rubriques: RubriqueAggregate[] = Array.from(map.values()).map(({ rule, debit, credit }) => ({
+    rubrique: rule.rubrique,
+    form: rule.form,
+    label: rule.label,
+    total_debit: round2(debit),
+    total_credit: round2(credit),
+    balance: round2(debit - credit)
+  })).sort((a,b)=> a.rubrique.localeCompare(b.rubrique));
+
+  return { rubriques, amortizations };
+}
+
+// Helper pour calculer un résultat courant (Produits - Charges) basique selon rubriques actuelles.
+// Hypothèses: Rubriques Produits = CA (et potentiellement d'autres plus tard). Charges = tout le reste sauf CA & CA_Moins.
+export function computeResultatCourant(rubriques: RubriqueAggregate[]): number {
+  let produits = 0; let charges = 0; let caMoins = 0;
+  for (const r of rubriques) {
+    if (r.rubrique === 'CA') produits += r.total_credit - r.total_debit; // ventes nettes
+    else if (r.rubrique === 'CA_Moins') caMoins += r.total_debit - r.total_credit; // rabais (débits)
+    else { charges += r.total_debit - r.total_credit; }
+  }
+  const netProduits = produits - caMoins; // CA net
+  return round2(netProduits - charges);
+}

--- a/src/lib/guard.test.ts
+++ b/src/lib/guard.test.ts
@@ -1,11 +1,31 @@
-import { describe, it, expect } from 'vitest';
-import { evaluateAccess } from './guard';
+import {describe, expect, it} from 'vitest';
+import type {User} from '@supabase/supabase-js';
+import {evaluateAccess} from './guard';
 
-// Helpers user objects minimaux
-const user = (role: 'admin' | 'user'): any => ({
-  app_metadata: { role },
-  user_metadata: { role },
-});
+// Fabrique user minimal (cast vers User pour tests uniquement)
+function makeUser(role: 'admin' | 'user'): User {
+   // Cast contrôlé contexte test
+    return {
+      id: 'test-id',
+      app_metadata: {role},
+      user_metadata: {role},
+      aud: 'authenticated',
+      role: 'authenticated',
+      email: `${role}@test.local`,
+      email_confirmed_at: new Date().toISOString(),
+      phone: '',
+      confirmation_sent_at: null,
+      confirmed_at: null,
+      last_sign_in_at: new Date().toISOString(),
+      factors: [],
+      identities: [],
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      app_roles: [],
+      phone_confirmed_at: null,
+      is_anonymous: false,
+  } as unknown as User;
+}
 
 describe('evaluateAccess', () => {
   it('retourne loading si loading', () => {
@@ -15,13 +35,12 @@ describe('evaluateAccess', () => {
     expect(evaluateAccess('user', null, false)).toBe('unauthenticated');
   });
   it('autorise user authentifié pour role user', () => {
-    expect(evaluateAccess('user', user('user'), false)).toBe('ok');
+    expect(evaluateAccess('user', makeUser('user'), false)).toBe('ok');
   });
   it('refuse user non admin pour role admin', () => {
-    expect(evaluateAccess('admin', user('user'), false)).toBe('forbidden');
+    expect(evaluateAccess('admin', makeUser('user'), false)).toBe('forbidden');
   });
   it('autorise admin pour role admin', () => {
-    expect(evaluateAccess('admin', user('admin'), false)).toBe('ok');
+    expect(evaluateAccess('admin', makeUser('admin'), false)).toBe('ok');
   });
 });
-

--- a/src/lib/ledger-pdf.ts
+++ b/src/lib/ledger-pdf.ts
@@ -1,0 +1,67 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import type { LedgerLine } from './ledger';
+
+interface LedgerLineWithTier extends LedgerLine { tier?: string }
+
+export interface LedgerPdfOptions {
+  title?: string;
+  account_code: string;
+  rows: LedgerLineWithTier[];
+  period: { from?: string | null; to?: string | null };
+  filters?: { q?: string | null };
+  truncateAt?: number;
+}
+
+const A4_WIDTH = 595.28;
+const A4_HEIGHT = 841.89;
+const LEFT = 36;
+const TOP = 40;
+const LINE_H = 14;
+const BOTTOM = 40;
+
+function asciiSafe(s: string): string { return s.replace(/\u2192/g, '->'); }
+function truncate(s: string, max: number) { return s.length > max ? s.slice(0, max - 1) + '…' : s; }
+
+export async function generateLedgerPdf(opts: LedgerPdfOptions): Promise<Uint8Array> {
+  const { title = 'Grand livre', account_code, rows, period, filters = {}, truncateAt = 5000 } = opts;
+  const pdf = await PDFDocument.create();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  let page = pdf.addPage([A4_WIDTH, A4_HEIGHT]);
+  page.setFont(font);
+  let y = A4_HEIGHT - TOP;
+
+  const col = { date: LEFT, tier: LEFT + 70, label: LEFT + 170, debit: LEFT + 360, credit: LEFT + 430, bal: LEFT + 500 };
+  const draw = (t: string, x: number, yy: number, size = 9) => page.drawText(asciiSafe(t), { x, y: yy - size, size, font });
+  const header = () => {
+    y = A4_HEIGHT - TOP;
+    draw(`${title} – Compte ${account_code}`, LEFT, y, 14); y -= LINE_H * 1.4;
+    draw(`Période: ${period.from || '—'} -> ${period.to || '—'}`, LEFT, y, 9); y -= LINE_H;
+    const f: string[] = [];
+    if (filters.q) f.push(`q=${filters.q}`);
+    if (f.length) { draw('Filtres: ' + f.join(', '), LEFT, y, 9); y -= LINE_H; }
+    const hy = y; y -= LINE_H;
+    draw('Date', col.date, hy, 10);
+    draw('Tier', col.tier, hy, 10);
+    draw('Désignation', col.label, hy, 10);
+    draw('Débit', col.debit, hy, 10);
+    draw('Crédit', col.credit, hy, 10);
+    draw('Solde', col.bal, hy, 10);
+  };
+
+  header();
+  const minY = BOTTOM + 50;
+  let count = 0;
+  for (const r of rows) {
+    if (count >= truncateAt) { draw('… (troncation)', LEFT, y, 9); break; }
+    if (y <= minY) { page = pdf.addPage([A4_WIDTH, A4_HEIGHT]); page.setFont(font); header(); }
+    draw(r.date.slice(0,10), col.date, y, 9);
+    draw(truncate(r.tier || '', 14), col.tier, y, 9);
+    draw(truncate(r.designation, 28), col.label, y, 9);
+    draw(r.debit ? r.debit.toFixed(2) : '', col.debit, y, 9);
+    draw(r.credit ? r.credit.toFixed(2) : '', col.credit, y, 9);
+    draw(r.balance.toFixed(2), col.bal, y, 9);
+    y -= LINE_H;
+    count++;
+  }
+  return await pdf.save();
+}

--- a/src/lib/security-headers.test.ts
+++ b/src/lib/security-headers.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { buildSecurityHeaders } from './security-headers';
+
+function getCsp(headers: { key: string; value: string }[]) {
+  return headers.find(h => h.key === 'Content-Security-Policy')?.value || '';
+}
+
+function parseDirective(csp: string, name: string) {
+  const re = new RegExp(`${name} ([^;]+)`);
+  const m = csp.match(re);
+  return m ? m[1].trim().split(/\s+/) : [];
+}
+
+describe('buildSecurityHeaders', () => {
+  it('inclut localhost:54321 en dev sans URL explicite', () => {
+    const hs = buildSecurityHeaders({ env: 'development', supabaseUrl: undefined });
+    const csp = getCsp(hs);
+    const connect = parseDirective(csp, 'connect-src');
+    expect(connect).toContain("http://localhost:54321");
+    expect(connect).toContain("ws://localhost:54321");
+  });
+  it('ajoute origin Supabase custom et son ws', () => {
+    const hs = buildSecurityHeaders({ env: 'development', supabaseUrl: 'http://localhost:54321' });
+    const csp = getCsp(hs);
+    const connect = parseDirective(csp, 'connect-src');
+    // pas de doublons multiples critiques, présence origin
+    const occurrences = connect.filter(s => s === 'http://localhost:54321').length;
+    expect(occurrences).toBeGreaterThanOrEqual(1);
+  });
+  it('gère URL cloud https', () => {
+    const hs = buildSecurityHeaders({ env: 'production', supabaseUrl: 'https://proj.supabase.co' });
+    const csp = getCsp(hs);
+    const connect = parseDirective(csp, 'connect-src');
+    expect(connect.some(s => s.includes('proj.supabase.co'))).toBe(true);
+    expect(connect.some(s => s.startsWith('wss://proj.supabase.co'))).toBe(true);
+    // HSTS présent en prod
+    expect(hs.find(h=>h.key==='Strict-Transport-Security')).toBeDefined();
+  });
+});
+

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -1,0 +1,49 @@
+interface BuildSecurityHeadersArgs { env: string; supabaseUrl?: string; }
+
+/** Construit les en-têtes sécurité (CSP dynamique). */
+export function buildSecurityHeaders({ env, supabaseUrl }: BuildSecurityHeadersArgs) {
+  const isProd = env === 'production';
+  let supabaseOrigin = '';
+  let supabaseWs = '';
+  if (supabaseUrl) {
+    try {
+      const u = new URL(supabaseUrl.replace(/\/$/, ''));
+      supabaseOrigin = u.origin;
+      supabaseWs = (u.protocol === 'https:' ? 'wss://' : 'ws://') + u.host;
+    } catch { /* ignore */ }
+  }
+  // Sources connect explicites avec schémas
+  const connectSources = ["'self'", 'https://*.supabase.co', 'wss://*.supabase.co'];
+  if (supabaseOrigin && !connectSources.includes(supabaseOrigin)) connectSources.push(supabaseOrigin);
+  if (supabaseWs && !connectSources.includes(supabaseWs)) connectSources.push(supabaseWs);
+  // autoriser localhost:54321 en fallback si pas d'URL fournie (dev local supabase cli)
+  if (!supabaseOrigin && env !== 'production') {
+    connectSources.push('http://localhost:54321', 'ws://localhost:54321');
+  }
+  const scriptSources = ["'self'", "'unsafe-inline'"]; if (!isProd) scriptSources.push("'unsafe-eval'"); scriptSources.push('https://*.supabase.co');
+  if (supabaseOrigin && !scriptSources.includes(supabaseOrigin)) scriptSources.push(supabaseOrigin);
+  const csp = [
+    "default-src 'self'",
+    `script-src ${scriptSources.join(' ')}`.trim(),
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self'",
+    `connect-src ${connectSources.join(' ')}`,
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join('; ');
+  const headers = [
+    { key: 'X-Frame-Options', value: 'DENY' },
+    { key: 'X-Content-Type-Options', value: 'nosniff' },
+    { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+    { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+    { key: 'X-XSS-Protection', value: '0' },
+    { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+    { key: 'Cross-Origin-Resource-Policy', value: 'same-origin' },
+    ...(isProd ? [{ key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' }] : []),
+    { key: 'Content-Security-Policy', value: csp },
+  ];
+  return headers;
+}


### PR DESCRIPTION
Résumé: Mise en place d’un moteur générique de mapping comptes PCG → rubriques formulaires (2033C) basé sur un fichier JSON configurable (pas de hard‑code). Fournit agrégats par rubrique + extraction des dotations d’amortissements (6811*) pour futur 2033‑E. Ajout d’un helper de calcul du résultat courant.
Changements principaux:
config/config-pcg.json : règles (prefix → rubrique, form, label)
lib/accounting/mapToRubriques.ts : moteur d’agrégation + computeResultatCourant
Tests unitaires dédiés mapToRubriques.test.ts
Documentation ajoutée au README (section Extension Mapping PCG -> Rubriques)
Règles clés:
Match par préfixe, priorité au préfixe le plus long
achat = débit, vente = crédit
balance = débit – crédit (aligné avec balance existante)
Filtre période optionnel
Comptes non mappés ignorés silencieusement
Rubriques implémentées (2033C):
CA, CA_Moins, ChargesExternes, Assurances, ServicesExterieurs, ImpotsTaxes, DotationsAmortissements
Tests:
5 cas couvrant: ventes/rabais, priorité préfixes, multi charges + 6811, filtre période, ignore comptes non mappés
Tous les tests du repo passent (30/30)
Comment étendre:
Ajouter une ligne dans config/config-pcg.json (nouveau prefix)
(Optionnel) Ajouter test
pnpm test

Vérifications:
Typecheck & tests OK
Pas d’impact sur flux existants (module isolé)
Merci de reviewer:
Cohérence noms rubriques
Structure JSON (peut-on figer la convention avant d’ajouter d’autres formulaires)
Checklist: [ ] Nommage rubriques validé [ ] OK pour commencer API + exports sur cette base
Références: Issue/Phase: P4-A
Prêt à merge après validation.