### PR TITLE
P4-B: 2033-C (API + UI + export XLSX)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ Exports: `/api/reports/ledger/export?account_code=...&format=csv|pdf` (+ from/to
 Intégration: depuis la Balance, lien "Grand livre" pré-remplit compte & période.
 Limites: pas de pagination (warning si volumétrie à implémenter plus tard).
 
+### 2033-C (Compte de résultat simplifié)
+Page: `/reports/2033c` (admin).
+Filtres: `from`, `to`, `q` (designation|tier|account_code), `account_code`.
+API JSON: `/api/reports/2033c` → `{ rubriques: [...], totals: { produits, charges, amortissements, resultat } }`.
+Export XLSX: `/api/reports/2033c/export?format=xlsx` (onglets `2033C`, `Meta`). Header `X-Truncated: true` si > limites.
+Structure UI:
+- Produits: CA, Rabais (négatif)
+- Charges: externes, assurances, impôts, services (selon mapping dynamique)
+- Dotations: amortissements (6811*)
+Totaux calculés: Total Produits, Total Charges, Dotations, Résultat = Produits - Charges - Dotations.
+Extension: ajouter prefixes dans `config/config-pcg.json` (form 2033C). La page reflète automatiquement.
+
 ## Intégration Continue (CI)
 Pipeline GitHub Actions (workflow `ci.yml`) : lint, typecheck, tests unitaires, build et e2e Playwright (artefacts exports dans `e2e-exports`). Variables d'environnement injectées via secrets (Supabase + DB). Pour reproduire en local :
 ```bash

--- a/src/app/api/reports/2033c/export/route.ts
+++ b/src/app/api/reports/2033c/export/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { compute2033C } from '@/lib/accounting/compute2033c';
+import * as XLSX from 'xlsx';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+const MAX_ROWS = 10000;
+
+export async function GET(req: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return new Response('Unauthorized', { status: 401 });
+  try { assertAdmin(user); } catch { return new Response('Forbidden', { status: 403 }); }
+  const { searchParams } = new URL(req.url);
+  const format = searchParams.get('format') === 'xlsx' ? 'xlsx' : 'xlsx';
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  const q = searchParams.get('q');
+  const account_code = searchParams.get('account_code');
+  const result = await compute2033C({ userId: user.id, from, to, q, account_code });
+
+  // Construire dataset agrégé
+  const rows = result.rubriques.map(r => {
+    let montant: number;
+    if (r.rubrique === 'CA') montant = r.total_credit - r.total_debit; // Produits positifs
+    else if (r.rubrique === 'CA_Moins') montant = -(r.total_debit - r.total_credit); // afficher rabais en négatif
+    else if (r.rubrique === 'DotationsAmortissements') montant = r.total_debit - r.total_credit; // charges
+    else montant = r.total_debit - r.total_credit; // charges
+    return { Rubrique: r.label, Code: r.rubrique, Montant: montant };
+  });
+  // Totaux
+  rows.push({ Rubrique: 'TOTAL PRODUITS', Code: 'TOTAL_PROD', Montant: result.totals.produits });
+  rows.push({ Rubrique: 'TOTAL CHARGES', Code: 'TOTAL_CHARGES', Montant: result.totals.charges });
+  rows.push({ Rubrique: 'DOTATIONS AMORT.', Code: 'TOTAL_DOT', Montant: result.totals.amortissements });
+  rows.push({ Rubrique: 'RESULTAT', Code: 'RESULTAT', Montant: result.totals.resultat });
+
+  let truncated = false;
+  let exportRows = rows;
+  if (rows.length > MAX_ROWS) { truncated = true; exportRows = rows.slice(0, MAX_ROWS); }
+
+  const wb = XLSX.utils.book_new();
+  const metaSheetData = [
+    { Cle: 'Periode_From', Valeur: from || '' },
+    { Cle: 'Periode_To', Valeur: to || '' },
+    { Cle: 'Total_Entries', Valeur: result.count_entries },
+    { Cle: 'Truncated', Valeur: truncated || result.truncated ? 'true':'false' }
+  ];
+  const wsMeta = XLSX.utils.json_to_sheet(metaSheetData);
+  XLSX.utils.book_append_sheet(wb, wsMeta, 'Meta');
+  const ws = XLSX.utils.json_to_sheet(exportRows.map(r => ({ Rubrique: r.Rubrique, Code: r.Code, Montant: typeof r.Montant === 'number' ? r.Montant.toFixed(2) : r.Montant })));
+  XLSX.utils.book_append_sheet(wb, ws, '2033C');
+  const buf = XLSX.write(wb, { bookType: 'xlsx', type: 'buffer' });
+  const headers: Record<string,string> = {
+    'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'Content-Disposition': 'attachment; filename="2033c.xlsx"'
+  };
+  if (truncated || result.truncated) headers['X-Truncated'] = 'true';
+  return new Response(new Uint8Array(buf), { headers });
+}

--- a/src/app/api/reports/2033c/route.ts
+++ b/src/app/api/reports/2033c/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { compute2033C } from '@/lib/accounting/compute2033c';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return new Response('Unauthorized', { status: 401 });
+  try { assertAdmin(user); } catch { return new Response('Forbidden', { status: 403 }); }
+  const { searchParams } = new URL(req.url);
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  const q = searchParams.get('q');
+  const account_code = searchParams.get('account_code');
+  const result = await compute2033C({ userId: user.id, from, to, q, account_code });
+  return Response.json({ rubriques: result.rubriques, totals: result.totals });
+}
+

--- a/src/app/reports/2033c/page.tsx
+++ b/src/app/reports/2033c/page.tsx
@@ -1,0 +1,132 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { compute2033C } from '@/lib/accounting/compute2033c';
+import Link from 'next/link';
+
+export const dynamic = 'force-dynamic';
+
+interface Search { from?: string|null; to?: string|null; q?: string|null; account_code?: string|null; }
+
+export default async function C2033CPage({ searchParams }: { searchParams: Promise<Record<string,string|string[]|undefined>> }) {
+  const sp = await searchParams;
+  const from = sp.from as string | undefined;
+  const to = sp.to as string | undefined;
+  const q = sp.q as string | undefined;
+  const account_code = sp.account_code as string | undefined;
+
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return <div className="p-8">Non authentifié</div>;
+  try { assertAdmin(user); } catch { return <div className="p-8">Accès administrateur requis</div>; }
+
+  const data = await compute2033C({ userId: user.id, from, to, q, account_code });
+  const hasFilters = !!(from||to||q||account_code);
+
+  const rubriqueMap = Object.fromEntries(data.rubriques.map(r=>[r.rubrique,r]));
+  const get = (code: string) => rubriqueMap[code];
+
+  const produitsRows = [ get('CA'), get('CA_Moins') ].filter(Boolean);
+  const chargesRows = data.rubriques.filter(r => !['CA','CA_Moins','DotationsAmortissements'].includes(r.rubrique));
+  const dotationsRows = [ get('DotationsAmortissements') ].filter(Boolean);
+
+  function montantProduit(r:any){ if(!r) return 0; if(r.rubrique==='CA') return r.total_credit - r.total_debit; if(r.rubrique==='CA_Moins') return -(r.total_debit - r.total_credit); return 0; }
+  function montantCharge(r:any){ if(!r) return 0; return r.total_debit - r.total_credit; }
+
+  return <main className="p-6 max-w-5xl mx-auto space-y-6">
+    <header className="flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-semibold">Compte de résultat 2033-C</h1>
+        <p className="text-sm text-muted-foreground">Agrégation simplifiée (LMNP)</p>
+      </div>
+      <div className="flex gap-2">
+        <a className="btn text-xs" href={`/api/reports/2033c/export?format=xlsx${from?`&from=${from}`:''}${to?`&to=${to}`:''}${q?`&q=${q}`:''}${account_code?`&account_code=${account_code}`:''}`}>Export XLSX</a>
+      </div>
+    </header>
+
+    <section className="card p-4 space-y-4 text-sm">
+      <form className="grid md:grid-cols-6 gap-3" method="get">
+        <input type="date" name="from" defaultValue={from||''} className="input" />
+        <input type="date" name="to" defaultValue={to||''} className="input" />
+        <input name="account_code" placeholder="Compte" defaultValue={account_code||''} className="input" />
+        <input name="q" placeholder="Recherche (designation / tier / compte)" defaultValue={q||''} className="input md:col-span-2" />
+        <div className="flex items-center gap-2 md:col-span-1">
+          <button className="btn-primary">Filtrer</button>
+          {hasFilters && <a href="/reports/2033c" className="text-xs underline">Reset</a>}
+        </div>
+        <div className="md:col-span-6 flex flex-wrap gap-4 mt-2 text-xs text-muted-foreground">
+          {from && <span>Période: {from} → {to || '…'}</span>}
+          {hasFilters && <span className="px-2 py-0.5 rounded bg-gray-200">Filtre actif</span>}
+        </div>
+      </form>
+    </section>
+
+    <section className="card p-4 overflow-x-auto text-sm space-y-6">
+      {/* PRODUITS */}
+      <div>
+        <h2 className="font-semibold mb-2">Produits</h2>
+        <table className="w-full mb-2">
+          <tbody>
+            {produitsRows.map(r => <tr key={r.rubrique} className="border-b last:border-none">
+              <td className="py-1 pr-4">{r.label}</td>
+              <td className="py-1 text-right tabular-nums">{montantProduit(r).toFixed(2)}</td>
+            </tr>)}
+            {!produitsRows.length && <tr><td colSpan={2} className="py-2 text-muted-foreground">Aucun produit</td></tr>}
+            <tr className="font-medium">
+              <td className="py-1 pr-4">Total Produits</td>
+              <td className="py-1 text-right tabular-nums">{data.totals.produits.toFixed(2)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* CHARGES */}
+      <div>
+        <h2 className="font-semibold mb-2">Charges</h2>
+        <table className="w-full mb-2">
+          <tbody>
+            {chargesRows.map(r => <tr key={r.rubrique} className="border-b last:border-none">
+              <td className="py-1 pr-4">{r.label}</td>
+              <td className="py-1 text-right tabular-nums">{montantCharge(r).toFixed(2)}</td>
+            </tr>)}
+            {!chargesRows.length && <tr><td colSpan={2} className="py-2 text-muted-foreground">Aucune charge</td></tr>}
+            <tr className="font-medium">
+              <td className="py-1 pr-4">Total Charges</td>
+              <td className="py-1 text-right tabular-nums">{data.totals.charges.toFixed(2)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* DOTATIONS */}
+      <div>
+        <h2 className="font-semibold mb-2">Dotations</h2>
+        <table className="w-full mb-2">
+          <tbody>
+            {dotationsRows.map(r => <tr key={r.rubrique} className="border-b last:border-none">
+              <td className="py-1 pr-4">{r.label}</td>
+              <td className="py-1 text-right tabular-nums">{montantCharge(r).toFixed(2)}</td>
+            </tr>)}
+            {!dotationsRows.length && <tr><td colSpan={2} className="py-2 text-muted-foreground">Aucune dotation</td></tr>}
+            <tr className="font-medium">
+              <td className="py-1 pr-4">Total Dotations</td>
+              <td className="py-1 text-right tabular-nums">{data.totals.amortissements.toFixed(2)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="text-sm font-semibold flex justify-between border-t pt-3">
+        <span>Résultat</span>
+        <span className="tabular-nums">{data.totals.resultat.toFixed(2)}</span>
+      </div>
+      {data.totals.resultat < 0 && <div className="text-xs text-red-600">Résultat négatif</div>}
+      {(data.truncated) && <div className="text-xs text-amber-600">Données tronquées (volume &gt; limite interne)</div>}
+
+      <div className="text-xs text-muted-foreground flex flex-wrap gap-4">
+        <span>Période: {from || '—'} → {to || '—'}</span>
+        <Link href="/reports/2033e" className="underline">Aller 2033-E (amortissements)</Link>
+      </div>
+    </section>
+  </main>;
+}
+

--- a/src/lib/accounting/compute2033c.test.ts
+++ b/src/lib/accounting/compute2033c.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { prisma } from '../prisma';
+import { compute2033C } from './compute2033c';
+
+// Ce test suppose base en mémoire / DB test isolée. On insère puis on supprime.
+// Dataset: 706=1000 (vente), 606=300 (achat), 616=50 (achat), 635=20 (achat), 6811=200 (achat)
+
+const userId = '00000000-0000-0000-0000-0000000002033';
+
+beforeAll(async () => {
+  // Nettoyage préalable éventuel
+  await prisma.journalEntry.deleteMany({ where: { user_id: userId } });
+  const baseDate = new Date('2025-01-15');
+  await prisma.journalEntry.createMany({ data: [
+    { user_id: userId, type: 'vente', date: baseDate, designation: 'Vente test', tier: 'ClientA', account_code: '706', amount: 1000, currency: 'EUR' },
+    { user_id: userId, type: 'achat', date: baseDate, designation: 'Achat charges', tier: 'Fourn1', account_code: '606', amount: 300, currency: 'EUR' },
+    { user_id: userId, type: 'achat', date: baseDate, designation: 'Assurance', tier: 'Assureur', account_code: '616', amount: 50, currency: 'EUR' },
+    { user_id: userId, type: 'achat', date: baseDate, designation: 'Taxe', tier: 'Etat', account_code: '635', amount: 20, currency: 'EUR' },
+    { user_id: userId, type: 'achat', date: baseDate, designation: 'Amort', tier: 'Sys', account_code: '6811', amount: 200, currency: 'EUR' },
+  ]});
+});
+
+afterAll(async () => {
+  await prisma.journalEntry.deleteMany({ where: { user_id: userId } });
+});
+
+describe('compute2033C', () => {
+  it('calcule totaux attendus', async () => {
+    const res = await compute2033C({ userId });
+    expect(res.totals.produits).toBe(1000); // CA
+    expect(res.totals.charges).toBe(370);   // 300 + 50 + 20
+    expect(res.totals.amortissements).toBe(200);
+    expect(res.totals.resultat).toBe(430);  // 1000 - 370 - 200
+  });
+});

--- a/src/lib/accounting/compute2033c.ts
+++ b/src/lib/accounting/compute2033c.ts
@@ -1,0 +1,60 @@
+import { prisma } from '../prisma';
+import { mapToRubriques, RubriqueAggregate } from './mapToRubriques';
+
+export interface C2033CParams { userId: string; from?: string | null; to?: string | null; q?: string | null; account_code?: string | null; }
+export interface C2033CTotals { produits: number; charges: number; amortissements: number; resultat: number; }
+export interface C2033CResult { rubriques: RubriqueAggregate[]; totals: C2033CTotals; truncated: boolean; count_entries: number; }
+
+const MAX_ENTRIES = 20000; // seuil de sécurité
+
+function safeParse(n: any): number { const v = typeof n === 'number' ? n : parseFloat(n); return isNaN(v) ? 0 : v; }
+
+function buildWhere(p: C2033CParams) {
+  const where: any = { user_id: p.userId };
+  if (p.from || p.to) where.date = {};
+  if (p.from) where.date.gte = new Date(p.from as string);
+  if (p.to) where.date.lte = new Date(p.to as string);
+  const ors: any[] = [];
+  if (p.q) {
+    ors.push({ designation: { contains: p.q, mode: 'insensitive' } });
+    ors.push({ tier: { contains: p.q, mode: 'insensitive' } });
+    ors.push({ account_code: { contains: p.q, mode: 'insensitive' } });
+  }
+  if (p.account_code) {
+    where.account_code = { contains: p.account_code, mode: 'insensitive' };
+  }
+  if (ors.length) where.OR = ors;
+  return where;
+}
+
+function computeTotals(rubriques: RubriqueAggregate[]): C2033CTotals {
+  const find = (code: string) => rubriques.find(r => r.rubrique === code);
+  const ca = find('CA');
+  const rabais = find('CA_Moins');
+  const dotations = find('DotationsAmortissements');
+  const produitsCA = (ca ? (ca.total_credit - ca.total_debit) : 0) - (rabais ? (rabais.total_debit - rabais.total_credit) : 0);
+  let charges = 0;
+  for (const r of rubriques) {
+    if (['CA','CA_Moins','DotationsAmortissements'].includes(r.rubrique)) continue;
+    // charges deviennent débit - crédit (positif attendu)
+    charges += (r.total_debit - r.total_credit);
+  }
+  const amortissements = dotations ? (dotations.total_debit - dotations.total_credit) : 0;
+  const resultat = produitsCA - charges - amortissements;
+  return { produits: round2(produitsCA), charges: round2(charges), amortissements: round2(amortissements), resultat: round2(resultat) };
+}
+
+function round2(n: number){ return Math.round(n*100)/100; }
+
+export async function compute2033C(params: C2033CParams): Promise<C2033CResult> {
+  const where = buildWhere(params);
+  const entries = await prisma.journalEntry.findMany({ where, orderBy: { date: 'asc' } });
+  let truncated = false;
+  let slice = entries;
+  if (entries.length > MAX_ENTRIES) { truncated = true; slice = entries.slice(0, MAX_ENTRIES); }
+  const mapped = mapToRubriques(slice.map(e => ({ type: e.type, account_code: e.account_code, amount: safeParse(e.amount), date: e.date })), { from: params.from ? new Date(params.from) : undefined, to: params.to ? new Date(params.to) : undefined });
+  const totals = computeTotals(mapped.rubriques);
+  return { rubriques: mapped.rubriques, totals, truncated, count_entries: entries.length };
+}
+
+export { computeTotals };

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -202,6 +202,15 @@ let achatEditedGlobal: string | undefined;
       expect(await ledgerCsv[0].path()).toBeTruthy();
       saveDownloadCopy(await ledgerCsv[0].path(), `ledger-${UNIQUE_RUN_ID}.csv`);
     }
+
+    // 2033C
+    await page.goto('/reports/2033c');
+    await expect(page.locator('h1:has-text("Compte de résultat 2033-C")')).toBeVisible();
+    const export2033c = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('a:has-text("Export XLSX")')
+    ]);
+    expect(await export2033c[0].path()).toBeTruthy();
   });
 
   test('5) RLS second utilisateur iso', async ({ browser }) => {


### PR DESCRIPTION
Résumé: Ajout du compte de résultat simplifié 2033-C (admin) avec API JSON, page UI filtrable et export XLSX. S’appuie sur le moteur de mapping (P4-A).
Nouveautés:
API JSON: GET /api/reports/2033c (filtres from,to,q,account_code)
Export XLSX: /api/reports/2033c/export?format=xlsx (onglets Meta + 2033C, header X-Truncated si applicable)
Page /reports/2033c: sections Produits, Charges, Dotations, totaux et résultat
Utilitaire compute2033c (agrégation + totaux + troncation)
Test unitaire compute2033c.test.ts (dataset de contrôle)
E2E: ajout visite /reports/2033c + export XLSX
README: section 2033-C
Totaux calculés: produits = CA - Rabais charges = somme rubriques charges (débit - crédit) amortissements = dotations (6811…) résultat = produits - charges - amortissements
Sécurité/Perf:
Accès admin uniquement (assertAdmin)
RLS côté DB
Troncation si > 20k écritures (JSON) ou >10k lignes export (X-Truncated)
Tests:
Unit: 31 tests verts (ajout 1 test)
E2E: scénario étendu (inclut export 2033C)
Points de revue:
Convention sens montants (rabais affiché négatif)
Noms rubriques & labels
Seuils troncation adaptés ?
Checklist: [ ] OK conventions montants [ ] OK labels rubriques [ ] Merge après validation
