### PR TITLE
P4-C: 2033-E (amortissements) — API + UI + export XLSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ Structure UI:
 Totaux calculés: Total Produits, Total Charges, Dotations, Résultat = Produits - Charges - Dotations.
 Extension: ajouter prefixes dans `config/config-pcg.json` (form 2033C). La page reflète automatiquement.
 
+### 2033-E (État des amortissements)
+Page: `/reports/2033e` (admin). Paramètre `year` (défaut année courante) + filtre `q` sur label.
+API JSON: `/api/reports/2033e?year=YYYY[&q=...]` -> `{ year, rows:[{asset_id,label,valeur_origine,amortissements_anterieurs,dotation_exercice,amortissements_cumules,valeur_nette}], totals, truncated }`.
+Export XLSX: `/api/reports/2033e/export?year=YYYY` (onglets `2033E`, `Meta`). Prorata temporis 1ère année (mois restants) et arrondis identiques à `computeLinearAmortization`.
+Troncation: >10k actifs (header `X-Truncated: true`).
+
 ## Intégration Continue (CI)
 Pipeline GitHub Actions (workflow `ci.yml`) : lint, typecheck, tests unitaires, build et e2e Playwright (artefacts exports dans `e2e-exports`). Variables d'environnement injectées via secrets (Supabase + DB). Pour reproduire en local :
 ```bash

--- a/src/app/api/reports/2033e/export/route.ts
+++ b/src/app/api/reports/2033e/export/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { compute2033E } from '@/lib/accounting/compute2033e';
+import * as XLSX from 'xlsx';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const yearStr = searchParams.get('year');
+  const year = yearStr ? parseInt(yearStr,10) : new Date().getFullYear();
+  if (isNaN(year)) return new Response('Bad year', { status: 400 });
+  const q = searchParams.get('q');
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return new Response('Unauthorized', { status: 401 });
+  try { assertAdmin(user); } catch { return new Response('Forbidden', { status: 403 }); }
+  const result = await compute2033E({ userId: user.id, year, q });
+
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.json_to_sheet(result.rows.map(r => ({
+    Asset: r.label,
+    Valeur_Origine: r.valeur_origine.toFixed(2),
+    Amort_Ant: r.amortissements_anterieurs.toFixed(2),
+    Dotation: r.dotation_exercice.toFixed(2),
+    Amort_Cumules: r.amortissements_cumules.toFixed(2),
+    Valeur_Nette: r.valeur_nette.toFixed(2)
+  })));
+  XLSX.utils.book_append_sheet(wb, ws, '2033E');
+  const wsMeta = XLSX.utils.json_to_sheet([
+    { Cle: 'Year', Valeur: year },
+    { Cle: 'Rows', Valeur: result.rows.length },
+    { Cle: 'Truncated', Valeur: result.truncated ? 'true':'false' }
+  ]);
+  XLSX.utils.book_append_sheet(wb, wsMeta, 'Meta');
+  const buf = XLSX.write(wb, { bookType: 'xlsx', type: 'buffer' });
+  const headers: Record<string,string> = {
+    'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'Content-Disposition': `attachment; filename="2033e-${year}.xlsx"`
+  };
+  if (result.truncated) headers['X-Truncated'] = 'true';
+  return new Response(new Uint8Array(buf), { headers });
+}
+

--- a/src/app/api/reports/2033e/route.ts
+++ b/src/app/api/reports/2033e/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { compute2033E } from '@/lib/accounting/compute2033e';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const yearStr = searchParams.get('year');
+  const year = yearStr ? parseInt(yearStr,10) : new Date().getFullYear();
+  if (isNaN(year)) return new Response('Bad year', { status: 400 });
+  const q = searchParams.get('q');
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return new Response('Unauthorized', { status: 401 });
+  try { assertAdmin(user); } catch { return new Response('Forbidden', { status: 403 }); }
+  const result = await compute2033E({ userId: user.id, year, q });
+  return Response.json(result);
+}
+

--- a/src/app/reports/2033e/page.tsx
+++ b/src/app/reports/2033e/page.tsx
@@ -1,0 +1,82 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { compute2033E } from '@/lib/accounting/compute2033e';
+
+export const dynamic = 'force-dynamic';
+
+export default async function C2033EPage({ searchParams }: { searchParams: Promise<Record<string,string|string[]|undefined>> }) {
+  const sp = await searchParams;
+  const yearStr = sp.year as string | undefined;
+  const q = sp.q as string | undefined;
+  const year = yearStr ? parseInt(yearStr,10) : new Date().getFullYear();
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return <div className="p-8">Non authentifié</div>;
+  try { assertAdmin(user); } catch { return <div className="p-8">Accès administrateur requis</div>; }
+  const data = await compute2033E({ userId: user.id, year, q });
+
+  return <main className="p-6 max-w-6xl mx-auto space-y-6">
+    <header className="flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-semibold">État des amortissements 2033-E</h1>
+        <p className="text-sm text-muted-foreground">Année {year}</p>
+      </div>
+      <div className="flex gap-2">
+        <a className="btn text-xs" href={`/api/reports/2033e/export?year=${year}${q?`&q=${encodeURIComponent(q)}`:''}`}>Export XLSX</a>
+      </div>
+    </header>
+
+    <section className="card p-4 space-y-4 text-sm">
+      <form className="flex flex-wrap gap-3 items-end" method="get">
+        <div className="flex flex-col">
+          <label className="text-xs font-medium mb-1">Année</label>
+          <input type="number" name="year" defaultValue={year} className="input w-32" />
+        </div>
+        <div className="flex flex-col">
+          <label className="text-xs font-medium mb-1">Recherche (label)</label>
+          <input name="q" defaultValue={q||''} placeholder="Label" className="input" />
+        </div>
+        <button className="btn-primary h-9">Filtrer</button>
+        {(yearStr || q) && <a href="/reports/2033e" className="underline text-xs">Reset</a>}
+        <div className="text-xs text-muted-foreground ml-auto">{data.rows.length} actifs affichés {data.truncated && '(tronqué)'} </div>
+      </form>
+    </section>
+
+    <div className="card p-4 overflow-x-auto text-sm">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="py-2 pr-4">Asset</th>
+            <th className="py-2 pr-4 text-right">Origine</th>
+            <th className="py-2 pr-4 text-right">Amort. antérieurs</th>
+            <th className="py-2 pr-4 text-right">Dotation {year}</th>
+            <th className="py-2 pr-4 text-right">Amort. cumulés</th>
+            <th className="py-2 pr-2 text-right">Valeur nette</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.rows.map(r => <tr key={r.asset_id} className="border-b last:border-none hover:bg-gray-50">
+            <td className="py-1 pr-4 font-medium">{r.label}</td>
+            <td className="py-1 pr-4 text-right tabular-nums">{r.valeur_origine.toFixed(2)}</td>
+            <td className="py-1 pr-4 text-right tabular-nums">{r.amortissements_anterieurs.toFixed(2)}</td>
+            <td className="py-1 pr-4 text-right tabular-nums">{r.dotation_exercice.toFixed(2)}</td>
+            <td className="py-1 pr-4 text-right tabular-nums">{r.amortissements_cumules.toFixed(2)}</td>
+            <td className="py-1 pr-2 text-right tabular-nums">{r.valeur_nette.toFixed(2)}</td>
+          </tr>)}
+          {!data.rows.length && <tr><td colSpan={6} className="py-6 text-center text-muted-foreground">Aucun actif</td></tr>}
+        </tbody>
+        <tfoot>
+          <tr className="font-semibold">
+            <td className="py-2 pr-4">Totaux</td>
+            <td className="py-2 pr-4 text-right">{data.totals.valeur_origine.toFixed(2)}</td>
+            <td className="py-2 pr-4 text-right">{data.totals.amortissements_anterieurs.toFixed(2)}</td>
+            <td className="py-2 pr-4 text-right">{data.totals.dotation_exercice.toFixed(2)}</td>
+            <td className="py-2 pr-4 text-right">{data.totals.amortissements_cumules.toFixed(2)}</td>
+            <td className="py-2 pr-2 text-right">{data.totals.valeur_nette.toFixed(2)}</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </main>;
+}
+

--- a/src/lib/accounting/compute2033e.test.ts
+++ b/src/lib/accounting/compute2033e.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { prisma } from '../prisma';
+import { compute2033E } from './compute2033e';
+
+const userId = '00000000-0000-0000-0000-0000000002034';
+
+beforeAll(async () => {
+  await prisma.asset.deleteMany({ where: { user_id: userId } });
+  await prisma.asset.create({ data: { id: 'asset1', user_id: userId, label: 'Machine Avril 2024', amount_ht: 20000, duration_years: 10, acquisition_date: new Date('2024-04-01'), account_code: '215' } });
+  await prisma.asset.create({ data: { id: 'asset2', user_id: userId, label: 'Mobilier Jan 2025', amount_ht: 6000, duration_years: 5, acquisition_date: new Date('2025-01-10'), account_code: '218' } });
+});
+
+afterAll(async () => {
+  await prisma.asset.deleteMany({ where: { user_id: userId } });
+});
+
+describe('compute2033E', () => {
+  it('calcule dotation prorata 2024 (1500) & pleine année 2025 (2000) pour 1er asset', async () => {
+    const res2024 = await compute2033E({ userId, year: 2024 });
+    const row2024 = res2024.rows.find(r => r.label.includes('Machine'))!;
+    expect(row2024.dotation_exercice).toBeCloseTo(1500, 2);
+    const res2025 = await compute2033E({ userId, year: 2025 });
+    const row2025 = res2025.rows.find(r => r.label.includes('Machine'))!;
+    expect(row2025.dotation_exercice).toBeCloseTo(2000, 2);
+    // Cumul 2025 = 1500 + 2000 = 3500
+    expect(row2025.amortissements_cumules).toBeCloseTo(3500, 2);
+  });
+  it('calcule multi-assets totaux', async () => {
+    const res2025 = await compute2033E({ userId, year: 2025 });
+    // Second asset (6000 / 5 ans) => dotation 2025 = 1200
+    const mobilier = res2025.rows.find(r => r.label.includes('Mobilier'))!;
+    expect(mobilier.dotation_exercice).toBeCloseTo(1200, 2);
+    // Totaux dotation 2025 = 2000 (machine) + 1200 (mobilier)
+    expect(res2025.totals.dotation_exercice).toBeCloseTo(3200, 2);
+  });
+});
+

--- a/src/lib/accounting/compute2033e.ts
+++ b/src/lib/accounting/compute2033e.ts
@@ -1,0 +1,53 @@
+import { prisma } from '../prisma';
+import { computeLinearAmortization } from '../asset-amortization';
+import type { Prisma } from '@prisma/client';
+
+export interface C2033EParams { userId: string; year: number; q?: string | null; }
+export interface C2033ERow {
+  asset_id: string;
+  label: string;
+  valeur_origine: number;
+  amortissements_anterieurs: number;
+  dotation_exercice: number;
+  amortissements_cumules: number;
+  valeur_nette: number;
+}
+export interface C2033EResult { year: number; rows: C2033ERow[]; totals: Omit<C2033ERow,'asset_id'|'label'>; truncated: boolean; count_assets: number; }
+
+const MAX_ASSETS = 10000;
+function round2(n: number){ return Math.round(n*100)/100; }
+
+export async function compute2033E(params: C2033EParams): Promise<C2033EResult> {
+  const { userId, year, q } = params;
+  const where: Prisma.AssetWhereInput = { user_id: userId };
+  if (q) where.label = { contains: q, mode: 'insensitive' };
+  const assets = await prisma.asset.findMany({ where, orderBy: { acquisition_date: 'asc' } });
+  let truncated = false;
+  let list = assets;
+  if (assets.length > MAX_ASSETS) { truncated = true; list = assets.slice(0, MAX_ASSETS); }
+
+  const rows: C2033ERow[] = [];
+  for (const a of list) {
+    const amount = Number(a.amount_ht);
+    if (!(amount > 0) || a.duration_years <= 0) continue;
+    const sched = computeLinearAmortization(amount, a.duration_years, a.acquisition_date);
+    const entry = sched.find(s => s.year === year);
+    if (!entry) continue; // année hors plage amortissement
+    const prev = sched.filter(s => s.year < year).at(-1);
+    const amortAnt = prev ? prev.cumul : 0;
+    const dotation = entry.dotation;
+    const cumul = amortAnt + dotation;
+    const nette = amount - cumul;
+    rows.push({ asset_id: a.id, label: a.label, valeur_origine: round2(amount), amortissements_anterieurs: round2(amortAnt), dotation_exercice: round2(dotation), amortissements_cumules: round2(cumul), valeur_nette: round2(nette) });
+  }
+  const totals = rows.reduce((acc, r) => {
+    acc.valeur_origine += r.valeur_origine;
+    acc.amortissements_anterieurs += r.amortissements_anterieurs;
+    acc.dotation_exercice += r.dotation_exercice;
+    acc.amortissements_cumules += r.amortissements_cumules;
+    acc.valeur_nette += r.valeur_nette;
+    return acc;
+  }, { valeur_origine:0, amortissements_anterieurs:0, dotation_exercice:0, amortissements_cumules:0, valeur_nette:0 });
+  (Object.keys(totals) as (keyof typeof totals)[]).forEach(k => { totals[k] = round2(totals[k]); });
+  return { year, rows, totals, truncated, count_assets: assets.length };
+}

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -211,6 +211,15 @@ let achatEditedGlobal: string | undefined;
       page.click('a:has-text("Export XLSX")')
     ]);
     expect(await export2033c[0].path()).toBeTruthy();
+
+    // 2033E
+    await page.goto('/reports/2033e');
+    await expect(page.locator('h1:has-text("État des amortissements 2033-E")')).toBeVisible();
+    const export2033e = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('a:has-text("Export XLSX")')
+    ]);
+    expect(await export2033e[0].path()).toBeTruthy();
   });
 
   test('5) RLS second utilisateur iso', async ({ browser }) => {


### PR DESCRIPTION
Résumé: Ajout de l’état des amortissements 2033‑E (admin) avec API JSON, page filtrable (année + recherche), export XLSX et calculs prorata temporis linéaires cohérents avec computeLinearAmortization.
Détails:
API: /api/reports/2033e (year, q) → rows + totals + truncated
Export: /api/reports/2033e/export?year=YYYY (onglets 2033E, Meta, header X-Truncated si >10k)
Page: /reports/2033e (table: Origine, Amort antérieurs, Dotation année, Cumul, Nette)
Calcul: linéaire, prorata 1ère année (mois restants), arrondis 2 décimales
Sécurité: admin only + RLS (pas de service role côté client)
Troncation: >10k actifs (flag truncated)
Tests:
Unit: prorata 20k/10 ans (1500 en 2024, 2000 en 2025, cumul 3500)
Multi‑assets: dotations cumulées vérifiées (2000 + 1200 = 3200)
E2E: export XLSX 2033E généré
Lint & build OK (types stricts)
Points de revue:
Noms colonnes/labels 2033E
Seuil troncation 10k adéquat ?
Besoin d’un export CSV complémentaire ?

Checklist avant merge: [ ] Validation labels et structure tableau [ ] OK seuil troncation [ ] Pas d’autre rubrique à ajouter
