### PR TITLE
P4-D: 2033-A (bilan simplifié v1) — API + UI + export XLSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ API JSON: `/api/reports/2033e?year=YYYY[&q=...]` -> `{ year, rows:[{asset_id,lab
 Export XLSX: `/api/reports/2033e/export?year=YYYY` (onglets `2033E`, `Meta`). Prorata temporis 1ère année (mois restants) et arrondis identiques à `computeLinearAmortization`.
 Troncation: >10k actifs (header `X-Truncated: true`).
 
+### 2033-A (Bilan simplifié v1)
+Page: `/reports/2033a` (admin). Paramètre `year` (défaut année courante) + filtre `q` sur labels assets.
+API JSON: `/api/reports/2033a?year=YYYY` → champs: immobilisations_brutes, amortissements_cumules, immobilisations_nettes, tresorerie (0 v1), actif_total, capitaux_propres_equilibrage (pour équilibrage), count_assets, truncated.
+Export XLSX: `/api/reports/2033a/export?year=YYYY` (onglets `2033A_Actif`, `2033A_Passif`, `Meta`).
+Limites v1: pas de dettes/détails trésorerie; capitaux propres calculés comme variable d’équilibre. Évolutions: ajout comptes tiers, dettes financières, disponibilités.
+
 ## Intégration Continue (CI)
 Pipeline GitHub Actions (workflow `ci.yml`) : lint, typecheck, tests unitaires, build et e2e Playwright (artefacts exports dans `e2e-exports`). Variables d'environnement injectées via secrets (Supabase + DB). Pour reproduire en local :
 ```bash

--- a/src/app/api/reports/2033a/export/route.ts
+++ b/src/app/api/reports/2033a/export/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { compute2033A } from '@/lib/accounting/compute2033a';
+import * as XLSX from 'xlsx';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const yearStr = searchParams.get('year');
+  const year = yearStr ? parseInt(yearStr,10) : new Date().getFullYear();
+  if (isNaN(year)) return new Response('Bad year', { status: 400 });
+  const q = searchParams.get('q');
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return new Response('Unauthorized', { status: 401 });
+  try { assertAdmin(user); } catch { return new Response('Forbidden', { status: 403 }); }
+  const r = await compute2033A({ userId: user.id, year, q });
+  const wb = XLSX.utils.book_new();
+  const actifRows = [
+    { Poste: 'Immobilisations nettes', Montant: r.immobilisations_nettes.toFixed(2) },
+    { Poste: 'Trésorerie (v1)', Montant: r.tresorerie.toFixed(2) },
+    { Poste: 'TOTAL ACTIF', Montant: r.actif_total.toFixed(2) }
+  ];
+  const passifRows = [
+    { Poste: 'Capitaux propres (équilibrage v1)', Montant: r.capitaux_propres_equilibrage.toFixed(2) },
+    { Poste: 'TOTAL PASSIF', Montant: r.capitaux_propres_equilibrage.toFixed(2) }
+  ];
+  const wsA = XLSX.utils.json_to_sheet(actifRows);
+  XLSX.utils.book_append_sheet(wb, wsA, '2033A_Actif');
+  const wsP = XLSX.utils.json_to_sheet(passifRows);
+  XLSX.utils.book_append_sheet(wb, wsP, '2033A_Passif');
+  const wsMeta = XLSX.utils.json_to_sheet([
+    { Cle: 'Year', Valeur: year },
+    { Cle: 'Assets_Count', Valeur: r.count_assets },
+    { Cle: 'Truncated', Valeur: r.truncated ? 'true':'false' }
+  ]);
+  XLSX.utils.book_append_sheet(wb, wsMeta, 'Meta');
+  const buf = XLSX.write(wb, { bookType: 'xlsx', type: 'buffer' });
+  const headers: Record<string,string> = {
+    'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'Content-Disposition': `attachment; filename="2033a-${year}.xlsx"`
+  };
+  if (r.truncated) headers['X-Truncated'] = 'true';
+  return new Response(new Uint8Array(buf), { headers });
+}
+

--- a/src/app/api/reports/2033a/route.ts
+++ b/src/app/api/reports/2033a/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { compute2033A } from '@/lib/accounting/compute2033a';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const yearStr = searchParams.get('year');
+  const year = yearStr ? parseInt(yearStr,10) : new Date().getFullYear();
+  if (isNaN(year)) return new Response('Bad year', { status: 400 });
+  const q = searchParams.get('q');
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return new Response('Unauthorized', { status: 401 });
+  try { assertAdmin(user); } catch { return new Response('Forbidden', { status: 403 }); }
+  const result = await compute2033A({ userId: user.id, year, q });
+  return Response.json(result);
+}
+

--- a/src/app/api/reports/2033c/export/route.ts
+++ b/src/app/api/reports/2033c/export/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   if (!user) return new Response('Unauthorized', { status: 401 });
   try { assertAdmin(user); } catch { return new Response('Forbidden', { status: 403 }); }
   const { searchParams } = new URL(req.url);
-  const format = searchParams.get('format') === 'xlsx' ? 'xlsx' : 'xlsx';
+  // Format fixé à XLSX (unique support pour l'instant)
   const from = searchParams.get('from');
   const to = searchParams.get('to');
   const q = searchParams.get('q');

--- a/src/app/reports/2033a/page.tsx
+++ b/src/app/reports/2033a/page.tsx
@@ -1,0 +1,74 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { assertAdmin } from '@/lib/auth';
+import { compute2033A } from '@/lib/accounting/compute2033a';
+
+export const dynamic = 'force-dynamic';
+
+export default async function C2033APage({ searchParams }: { searchParams: Promise<Record<string,string|string[]|undefined>> }) {
+  const sp = await searchParams;
+  const yearStr = sp.year as string | undefined;
+  const q = sp.q as string | undefined;
+  const year = yearStr ? parseInt(yearStr,10) : new Date().getFullYear();
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return <div className="p-8">Non authentifié</div>;
+  try { assertAdmin(user); } catch { return <div className="p-8">Accès administrateur requis</div>; }
+  const d = await compute2033A({ userId: user.id, year, q });
+  const balanceOK = d.actif_total === d.capitaux_propres_equilibrage;
+  return <main className="p-6 max-w-4xl mx-auto space-y-6">
+    <header className="flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-semibold">Bilan simplifié 2033-A (v1)</h1>
+        <p className="text-sm text-muted-foreground">Année {year}</p>
+      </div>
+      <div className="flex gap-2">
+        <a className="btn text-xs" href={`/api/reports/2033a/export?year=${year}${q?`&q=${encodeURIComponent(q)}`:''}`}>Export XLSX</a>
+      </div>
+    </header>
+    <section className="card p-4 space-y-4 text-sm">
+      <form className="flex flex-wrap gap-3 items-end" method="get">
+        <div className="flex flex-col">
+          <label className="text-xs font-medium mb-1">Année</label>
+          <input type="number" name="year" defaultValue={year} className="input w-32" />
+        </div>
+        <div className="flex flex-col">
+          <label className="text-xs font-medium mb-1">Recherche (label asset)</label>
+            <input name="q" defaultValue={q||''} placeholder="Label" className="input" />
+        </div>
+        <button className="btn-primary h-9">Filtrer</button>
+        {(yearStr || q) && <a href="/reports/2033a" className="underline text-xs">Reset</a>}
+        <div className="text-xs text-muted-foreground ml-auto">{d.count_assets} actifs (brut {d.immobilisations_brutes.toFixed(2)}) {d.truncated && '(tronqué)'} </div>
+      </form>
+    </section>
+    <div className="grid md:grid-cols-2 gap-6">
+      <div className="card p-4 text-sm">
+        <h2 className="font-semibold mb-3">Actif</h2>
+        <table className="w-full">
+          <tbody>
+            <tr><td className="py-1 pr-4">Immobilisations nettes</td><td className="py-1 text-right tabular-nums">{d.immobilisations_nettes.toFixed(2)}</td></tr>
+            <tr><td className="py-1 pr-4">Trésorerie (v1)</td><td className="py-1 text-right tabular-nums">{d.tresorerie.toFixed(2)}</td></tr>
+          </tbody>
+          <tfoot>
+            <tr className="font-semibold border-t"><td className="py-2 pr-4">Total Actif</td><td className="py-2 text-right tabular-nums">{d.actif_total.toFixed(2)}</td></tr>
+          </tfoot>
+        </table>
+      </div>
+      <div className="card p-4 text-sm">
+        <h2 className="font-semibold mb-3">Passif</h2>
+        <table className="w-full">
+          <tbody>
+            <tr><td className="py-1 pr-4">Capitaux propres (équilibrage v1)</td><td className="py-1 text-right tabular-nums">{d.capitaux_propres_equilibrage.toFixed(2)}</td></tr>
+          </tbody>
+          <tfoot>
+            <tr className="font-semibold border-t"><td className="py-2 pr-4">Total Passif</td><td className="py-2 text-right tabular-nums">{d.capitaux_propres_equilibrage.toFixed(2)}</td></tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+    <div className="text-xs flex items-center gap-3">
+      <span>Équilibre: {balanceOK ? <span className="text-green-600 font-medium">OK</span> : <span className="text-red-600 font-medium">Déséquilibré</span>}</span>
+      <span className="text-muted-foreground">(Nettes = Brut - Amort. cumulés au 31/12)</span>
+    </div>
+  </main>;
+}
+

--- a/src/app/reports/2033c/page.tsx
+++ b/src/app/reports/2033c/page.tsx
@@ -5,8 +5,6 @@ import Link from 'next/link';
 
 export const dynamic = 'force-dynamic';
 
-interface Search { from?: string|null; to?: string|null; q?: string|null; account_code?: string|null; }
-
 export default async function C2033CPage({ searchParams }: { searchParams: Promise<Record<string,string|string[]|undefined>> }) {
   const sp = await searchParams;
   const from = sp.from as string | undefined;
@@ -29,8 +27,9 @@ export default async function C2033CPage({ searchParams }: { searchParams: Promi
   const chargesRows = data.rubriques.filter(r => !['CA','CA_Moins','DotationsAmortissements'].includes(r.rubrique));
   const dotationsRows = [ get('DotationsAmortissements') ].filter(Boolean);
 
-  function montantProduit(r:any){ if(!r) return 0; if(r.rubrique==='CA') return r.total_credit - r.total_debit; if(r.rubrique==='CA_Moins') return -(r.total_debit - r.total_credit); return 0; }
-  function montantCharge(r:any){ if(!r) return 0; return r.total_debit - r.total_credit; }
+  type RRow = { rubrique: string; label: string; total_debit: number; total_credit: number } | undefined;
+  function montantProduit(r: RRow){ if(!r) return 0; if(r.rubrique==='CA') return r.total_credit - r.total_debit; if(r.rubrique==='CA_Moins') return -(r.total_debit - r.total_credit); return 0; }
+  function montantCharge(r: RRow){ if(!r) return 0; return r.total_debit - r.total_credit; }
 
   return <main className="p-6 max-w-5xl mx-auto space-y-6">
     <header className="flex items-center justify-between">
@@ -129,4 +128,3 @@ export default async function C2033CPage({ searchParams }: { searchParams: Promi
     </section>
   </main>;
 }
-

--- a/src/lib/accounting/compute2033a.test.ts
+++ b/src/lib/accounting/compute2033a.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { prisma } from '../prisma';
+import { compute2033A } from './compute2033a';
+import { compute2033E } from './compute2033e';
+
+const userId = '00000000-0000-0000-0000-0000000002035';
+
+beforeAll(async () => {
+  await prisma.asset.deleteMany({ where: { user_id: userId } });
+  // Asset 1: 20 000 / 10 ans / 2024-04-01
+  await prisma.asset.create({ data: { id: 'a1', user_id: userId, label: 'Machine Avril 2024', amount_ht: 20000, duration_years: 10, acquisition_date: new Date('2024-04-01'), account_code: '215' } });
+  // Asset 2: 3 000 / 3 ans / 2025-01-15
+  await prisma.asset.create({ data: { id: 'a2', user_id: userId, label: 'Mobilier Jan 2025', amount_ht: 3000, duration_years: 3, acquisition_date: new Date('2025-01-15'), account_code: '218' } });
+});
+
+afterAll(async () => {
+  await prisma.asset.deleteMany({ where: { user_id: userId } });
+});
+
+describe('compute2033A', () => {
+  it('année 2024: nettes = 20000 - 1500 = 18500', async () => {
+    const r2024 = await compute2033A({ userId, year: 2024 });
+    expect(r2024.immobilisations_brutes).toBe(20000);
+    expect(r2024.amortissements_cumules).toBeCloseTo(1500, 2);
+    expect(r2024.immobilisations_nettes).toBeCloseTo(18500, 2);
+    expect(r2024.actif_total).toBeCloseTo(r2024.capitaux_propres_equilibrage, 2);
+  });
+  it('année 2025: brut=23000 cumul=4500 net=18500 (3500 + 1000)', async () => {
+    const r2025 = await compute2033A({ userId, year: 2025 });
+    expect(r2025.immobilisations_brutes).toBe(23000);
+    expect(r2025.amortissements_cumules).toBeCloseTo(4500, 2); // 1500 + 2000 + 1000
+    expect(r2025.immobilisations_nettes).toBeCloseTo(18500, 2);
+    expect(r2025.actif_total).toBeCloseTo(r2025.capitaux_propres_equilibrage, 2);
+  });
+  it('cohérence partielle avec compute2033E (dotations)', async () => {
+    const e2025 = await compute2033E({ userId, year: 2025 });
+    // Dotation 2025: 2000 (machine) + 1000 (mobilier) = 3000
+    const totalDotation = e2025.rows.reduce((a,r)=> a + r.dotation_exercice, 0);
+    expect(totalDotation).toBeCloseTo(3000, 2);
+  });
+});
+

--- a/src/lib/accounting/compute2033a.ts
+++ b/src/lib/accounting/compute2033a.ts
@@ -1,0 +1,47 @@
+import {prisma} from '../prisma';
+import {computeLinearAmortization} from '../asset-amortization';
+import type {Prisma} from '@prisma/client';
+
+export interface C2033AParams { userId: string; year: number; q?: string | null; }
+export interface C2033AResult {
+  year: number;
+  immobilisations_brutes: number;
+  amortissements_cumules: number;
+  immobilisations_nettes: number;
+  tresorerie: number; // v1 fixe 0
+  actif_total: number;
+  capitaux_propres_equilibrage: number;
+  count_assets: number;
+  truncated: boolean;
+}
+
+const MAX_ASSETS = 20000;
+function round2(n: number){ return Math.round(n*100)/100; }
+
+export async function compute2033A(params: C2033AParams): Promise<C2033AResult> {
+  const { userId, year, q } = params;
+  const endDate = new Date(Date.UTC(year,11,31));
+  const where: Prisma.AssetWhereInput = { user_id: userId, acquisition_date: { lte: endDate } };
+  if (q) where.label = { contains: q, mode: 'insensitive' };
+  const assets = await prisma.asset.findMany({ where, orderBy: { acquisition_date: 'asc' } });
+  let truncated = false;
+  let list = assets;
+  if (assets.length > MAX_ASSETS) { truncated = true; list = assets.slice(0, MAX_ASSETS); }
+  let brut = 0; let cumul = 0;
+  for (const a of list) {
+    const amount = Number(a.amount_ht);
+    if (!(amount>0) || a.duration_years <=0) continue;
+    brut += amount;
+    const sched = computeLinearAmortization(amount, a.duration_years, a.acquisition_date);
+    const lastYearEntry = sched.filter(s => s.year <= year).at(-1);
+    if (lastYearEntry) cumul += lastYearEntry.cumul;
+  }
+  brut = round2(brut);
+  cumul = round2(cumul);
+  let nettes = round2(brut - cumul); if (nettes < 0) nettes = 0;
+  const tresorerie = 0; // v1
+  const actif_total = round2(nettes + tresorerie);
+   // équilibrage V1
+    return { year, immobilisations_brutes: brut, amortissements_cumules: cumul, immobilisations_nettes: nettes, tresorerie, actif_total, capitaux_propres_equilibrage: actif_total, count_assets: assets.length, truncated };
+}
+

--- a/src/lib/accounting/mapToRubriques.test.ts
+++ b/src/lib/accounting/mapToRubriques.test.ts
@@ -68,7 +68,7 @@ describe('mapToRubriques', () => {
   it('ignore montants NaN ou comptes non mappés', () => {
     const { rubriques } = mapToRubriques([
       entry({ type: 'vente', account_code: '999', amount: 500 }), // non mappé
-      entry({ type: 'achat', account_code: '606', amount: 'abc' as any }), // NaN
+      entry({ type: 'achat', account_code: '606', amount: 'abc' as unknown as number }), // NaN (cast volontaire)
       entry({ type: 'vente', account_code: '706', amount: 50 }),
     ]);
     expect(rubriques.find(r=> r.rubrique==='CA')?.total_credit).toBe(50);
@@ -89,4 +89,3 @@ describe('computeResultatCourant', () => {
     expect(res).toBe(55);
   });
 });
-

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -220,6 +220,15 @@ let achatEditedGlobal: string | undefined;
       page.click('a:has-text("Export XLSX")')
     ]);
     expect(await export2033e[0].path()).toBeTruthy();
+
+    // 2033A
+    await page.goto('/reports/2033a');
+    await expect(page.locator('h1:has-text("Bilan simplifié 2033-A")')).toBeVisible();
+    const export2033a = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('a:has-text("Export XLSX")')
+    ]);
+    expect(await export2033a[0].path()).toBeTruthy();
   });
 
   test('5) RLS second utilisateur iso', async ({ browser }) => {


### PR DESCRIPTION
Résumé: Ajout du bilan simplifié 2033-A (version 1) avec API JSON, page admin filtrable par année + recherche, et export XLSX (onglets Actif, Passif, Meta). Utilise les immobilisations (assets) et les amortissements linéaires pour calculer les valeurs nettes au 31/12 de l’année cible. Capitaux propres déterminés par équilibrage (pas encore de dettes / trésorerie réelle).
Changements principaux:
compute2033a.ts : calcul brut, amortissements cumulés, nettes, total actif/passif.
API JSON: /api/reports/2033a?year=YYYY
Export XLSX: /api/reports/2033a/export?year=YYYY (onglets 2033A_Actif / 2033A_Passif / Meta)
Page UI: /reports/2033a (admin) avec sélecteur d’année + q (label asset)
Tests unitaires: compute2033a.test.ts (2 assets, prorata cohérent avec 2033E)
E2E: extension scénario (visite + export 2033A)
README: section 2033-A (limitations v1)
Calculs:
Brut = somme montants d’origine des assets acquis avant ou le 31/12/année.
Amortissements cumulés: cumul linéaire prorata (computeLinearAmortization) jusqu’à fin d’année.
Nettes = Brut - Cumul (min 0).
Trésorerie (v1) = 0 (placeholder).
Actif total = Nettes + Trésorerie.
Capitaux propres (équilibrage) = Actif total (aucune autre rubrique passif v1).
Sécurité/Perf:
Accès admin + RLS (pas de service_role côté client).
Troncation si > 20k assets (flag truncated, header X-Truncated pour export).
Tests:
36 tests existants + nouveaux: PASS.
Bilan 2024: brut 20 000, cumul 1 500 (prorata), net 18 500.
Bilan 2025: brut 23 000, cumul 4 500, net 18 500.
Cohérence dotations avec 2033E (3000 sur 2025 répartis 2000 + 1000).
Limitations v1 / Next steps:
Pas de trésorerie réelle (compte 512) ni dettes (164/401/etc.).
Pas de ventilation capitaux propres (apport, résultat).
Améliorations futures: intégration journaux banque pour trésorerie, dettes & autres passifs, variation du résultat de l’exercice, mappings plus fins.
Points de revue suggérés:
Noms colonnes / labels UI.
Acceptation de l’équilibrage automatique des capitaux propres.
Seuil troncation 20k assets OK ?
Checklist: [ ] Validation wording UI [ ] OK sur structure export [ ] Merge après approbation