### PR TITLE
Seed démo: achats/ventes 2024-2025 + immobilisations + unseed (idempotent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,3 +219,15 @@ Extension:
 2. (Optionnel) Ajouter test dans `accountsCatalog.test.ts`.
 3. Lancer `pnpm test`.
 Fonctions utilitaires: `listFor(type)`, `isAllowed(code,type)`, `findClosest(code,type)`, `searchAccounts(q,type)`.
+
+## Seed de démo
+Commandes:
+- `pnpm db:seed:demo` (insère/maj écritures & assets suffixés "[seed]")
+- `pnpm db:unseed:demo` (supprime uniquement ces données)
+Variables requises: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, ADMIN_SEED_EMAIL, ADMIN_SEED_PASSWORD.
+Scénarios après seed:
+- Journaux: /journal/achats et /journal/ventes (filtres 2025)
+- 2033C: période 2025 (CA = 2400, rabais -50, charges achats ≈ 1602.5)
+- 2033E: années 2024 & 2025 (deux immobilisations)
+- 2033A: années 2024 & 2025 (nettes cohérentes)
+Idempotence: ré-exécuter la commande n’insère pas de doublon.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
     "db:format": "prisma format",
-    "db:seed:demo": "node scripts/seed-demo.js",
+    "db:seed:demo": "tsx scripts/dbSeedDemo.ts",
+    "db:unseed:demo": "tsx scripts/dbUnseedDemo.ts",
     "db:test": "dotenv -e .env -- node scripts/test-db.js",
     "db:test:pg": "dotenv -e .env -- node scripts/test-pg.js",
     "db:diagnose": "dotenv -e .env -- node scripts/diagnose-network.js",
@@ -63,6 +64,7 @@
     "prisma": "^6.14.0",
     "tailwindcss": "^4.1.11",
     "typescript": "^5",
+    "tsx": "^4.15.7",
     "vitest": "^1.6.0"
   },
   "engines": {

--- a/scripts/dbSeedDemo.ts
+++ b/scripts/dbSeedDemo.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env tsx
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { prisma } from '../src/lib/prisma';
+import { buildSeedData, SEED_SUFFIX } from '../src/lib/seedDemoCore';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const adminEmail = process.env.ADMIN_SEED_EMAIL;
+const adminPassword = process.env.ADMIN_SEED_PASSWORD || 'ChangeMe123!';
+const dryRun = process.env.DRY_RUN === '1';
+
+function assertEnv() {
+  const missing: string[] = [];
+  if (!url) missing.push('NEXT_PUBLIC_SUPABASE_URL');
+  if (!serviceKey) missing.push('SUPABASE_SERVICE_ROLE_KEY');
+  if (!adminEmail) missing.push('ADMIN_SEED_EMAIL');
+  if (missing.length) {
+    console.error('Variables manquantes:', missing.join(', '));
+    process.exit(1);
+  }
+}
+
+async function ensureAdmin(): Promise<string> {
+  const supabase = createClient(url!, serviceKey!, { auth: { autoRefreshToken: false, persistSession: false } });
+  // Pagination simple (perPage 200)
+  const { data: list, error: listError } = await supabase.auth.admin.listUsers({ perPage: 200 });
+  if (listError) throw listError;
+  let user = list.users.find(u => u.email?.toLowerCase() === adminEmail!.toLowerCase());
+  if (!user) {
+    if (dryRun) {
+      console.log('[dry-run] Création admin simulée');
+      return 'dry-run-user-id';
+    }
+    const { data, error } = await supabase.auth.admin.createUser({
+      email: adminEmail!,
+      password: adminPassword,
+      email_confirm: true,
+      user_metadata: { role: 'admin' },
+      app_metadata: { role: 'admin' }
+    });
+    if (error) throw error;
+    user = data.user;
+    console.log('Admin créé:', user.id);
+  } else {
+    // S'assure du rôle
+    if (!dryRun) {
+      await supabase.auth.admin.updateUserById(user.id, {
+        user_metadata: { ...(user.user_metadata||{}), role: 'admin' },
+        app_metadata: { ...(user.app_metadata||{}), role: 'admin' }
+      });
+    }
+    console.log('Admin existant:', user.id);
+  }
+  return user.id;
+}
+
+async function upsertJournal(userId: string) {
+  const data = buildSeedData();
+  let inserted = 0; let updated = 0;
+  for (const j of data.journal) {
+    const designation = j.designation + SEED_SUFFIX;
+    if (dryRun) { console.log('[dry-run] journal', j.date, j.type, j.account_code, designation, j.amount); continue; }
+    const existing = await prisma.journalEntry.findFirst({ where: { user_id: userId, type: j.type, date: new Date(j.date), account_code: j.account_code, designation } });
+    if (existing) {
+      // Optionnel: mise à jour montant si différent
+      if (Number(existing.amount) !== j.amount) {
+        await prisma.journalEntry.update({ where: { id: existing.id }, data: { amount: j.amount } });
+        updated++;
+      }
+    } else {
+      await prisma.journalEntry.create({ data: { user_id: userId, type: j.type, date: new Date(j.date), designation, tier: j.tier, account_code: j.account_code, amount: j.amount, currency: j.currency } });
+      inserted++;
+    }
+  }
+  return { inserted, updated };
+}
+
+async function upsertAssets(userId: string) {
+  const data = buildSeedData();
+  let inserted = 0; let updated = 0;
+  for (const a of data.assets) {
+    const label = a.label + SEED_SUFFIX;
+    if (dryRun) { console.log('[dry-run] asset', a.acquisition_date, label, a.amount_ht); continue; }
+    const existing = await prisma.asset.findFirst({ where: { user_id: userId, label, acquisition_date: new Date(a.acquisition_date) } });
+    if (existing) {
+      if (Number(existing.amount_ht) !== a.amount_ht || existing.duration_years !== a.duration_years) {
+        await prisma.asset.update({ where: { id: existing.id }, data: { amount_ht: a.amount_ht, duration_years: a.duration_years } });
+        updated++;
+      }
+    } else {
+      await prisma.asset.create({ data: { user_id: userId, label, amount_ht: a.amount_ht, duration_years: a.duration_years, acquisition_date: new Date(a.acquisition_date), account_code: a.account_code } });
+      inserted++;
+    }
+  }
+  return { inserted, updated };
+}
+
+(async () => {
+  try {
+    assertEnv();
+    const userId = await ensureAdmin();
+    const jr = await upsertJournal(userId);
+    const ar = await upsertAssets(userId);
+    console.log('\nRésumé seed demo');
+    console.log('Utilisateur:', userId);
+    console.log(`Journal: ${jr.inserted} insérés, ${jr.updated} mis à jour`);
+    console.log(`Assets: ${ar.inserted} insérés, ${ar.updated} mis à jour`);
+    console.log('\nTests conseillés:');
+    console.log('- /journal/achats?from=2025-01-01&to=2025-12-31');
+    console.log('- /reports/2033c?from=2025-01-01&to=2025-12-31');
+    console.log('- /reports/2033e?year=2025');
+    console.log('- /reports/2033a?year=2025');
+    if (dryRun) console.log('(dry-run: aucune écriture/asset créé)');
+  } catch (e:any) {
+    console.error('Seed demo échec:', e.message);
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+})();
+

--- a/scripts/dbUnseedDemo.ts
+++ b/scripts/dbUnseedDemo.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env tsx
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { prisma } from '../src/lib/prisma';
+import { SEED_SUFFIX } from '../src/lib/seedDemoCore';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const adminEmail = process.env.ADMIN_SEED_EMAIL;
+
+function assertEnv() {
+  const missing: string[] = [];
+  if (!url) missing.push('NEXT_PUBLIC_SUPABASE_URL');
+  if (!serviceKey) missing.push('SUPABASE_SERVICE_ROLE_KEY');
+  if (!adminEmail) missing.push('ADMIN_SEED_EMAIL');
+  if (missing.length) { console.error('Variables manquantes:', missing.join(', ')); process.exit(1); }
+}
+
+async function findAdminId(): Promise<string | null> {
+  const supabase = createClient(url!, serviceKey!, { auth: { autoRefreshToken: false, persistSession: false } });
+  const { data: list, error } = await supabase.auth.admin.listUsers({ perPage: 200 });
+  if (error) throw error;
+  const user = list.users.find(u => u.email?.toLowerCase() === adminEmail!.toLowerCase());
+  return user?.id || null;
+}
+
+(async () => {
+  try {
+    assertEnv();
+    const userId = await findAdminId();
+    if (!userId) {
+      console.log('Admin introuvable – rien à faire.');
+      process.exit(0);
+    }
+    const delJournal = await prisma.journalEntry.deleteMany({ where: { user_id: userId, designation: { endsWith: SEED_SUFFIX } } });
+    const delAssets  = await prisma.asset.deleteMany({ where: { user_id: userId, label: { endsWith: SEED_SUFFIX } } });
+    console.log('Unseed terminé');
+    console.log('Journal supprimé:', delJournal.count);
+    console.log('Assets supprimés:', delAssets.count);
+  } catch (e: any) {
+    console.error('Unseed échec:', e.message);
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+})();
+

--- a/src/lib/seedDemoCore.test.ts
+++ b/src/lib/seedDemoCore.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { buildSeedData } from './seedDemoCore';
+
+describe('buildSeedData', () => {
+  const data = buildSeedData();
+  it('contient journal et assets', () => {
+    expect(data.journal.length).toBeGreaterThan(5);
+    expect(data.assets.length).toBe(2);
+  });
+  it('montants clefs cohérents (loyers 2025)', () => {
+    const loyers = data.journal.filter(j=> j.type==='vente' && j.account_code==='706' && j.date.startsWith('2025-')).reduce((a,b)=>a+b.amount,0);
+    expect(loyers).toBe(2400); // janvier + février 1200 chacun
+  });
+  it('remise commerciale négative', () => {
+    const remise = data.journal.find(j=> j.account_code==='709' && j.date==='2025-03-31');
+    expect(remise?.amount).toBe(-50);
+  });
+});

--- a/src/lib/seedDemoCore.ts
+++ b/src/lib/seedDemoCore.ts
@@ -1,0 +1,45 @@
+export interface SeedJournalEntryBase {
+  type: 'achat' | 'vente';
+  date: string; // ISO (YYYY-MM-DD)
+  account_code: string;
+  designation: string; // sans suffixe
+  tier: string;
+  amount: number; // peut être négatif pour remise
+  currency: string;
+}
+export interface SeedAssetBase {
+  label: string; // sans suffixe
+  amount_ht: number;
+  duration_years: number;
+  acquisition_date: string; // YYYY-MM-DD
+  account_code: string;
+}
+export interface SeedData { journal: SeedJournalEntryBase[]; assets: SeedAssetBase[]; }
+
+export const SEED_SUFFIX = ' [seed]';
+
+export function buildSeedData(): SeedData {
+  const journal: SeedJournalEntryBase[] = [
+    // 2025 Achats
+    { type: 'achat', date: '2025-01-15', account_code: '606',  designation: 'Fournitures bureau',        tier: 'Fournisseur ABC', amount: 350.00, currency: 'EUR' },
+    { type: 'achat', date: '2025-02-10', account_code: '6063', designation: 'Petit outillage',           tier: 'Brico Services',  amount: 180.00, currency: 'EUR' },
+    { type: 'achat', date: '2025-03-05', account_code: '615',  designation: 'Réparation chauffe-eau',    tier: 'Plombier Martin', amount: 240.00, currency: 'EUR' },
+    { type: 'achat', date: '2025-03-28', account_code: '616',  designation: 'Assurance multirisque',     tier: 'Assurix',          amount: 120.00, currency: 'EUR' },
+    { type: 'achat', date: '2025-04-07', account_code: '62',   designation: 'Honoraires comptables',     tier: 'Cabinet ComptaX', amount: 300.00, currency: 'EUR' },
+    { type: 'achat', date: '2025-04-20', account_code: '627',  designation: 'Frais bancaires mensuels',  tier: 'Banque Z',         amount: 12.50,  currency: 'EUR' },
+    { type: 'achat', date: '2025-05-15', account_code: '635',  designation: 'Taxe foncière (acompte)',   tier: 'DGFIP',            amount: 400.00, currency: 'EUR' },
+    // 2025 Ventes
+    { type: 'vente', date: '2025-01-31', account_code: '706',  designation: 'Loyer janvier',             tier: 'Locataire Dupont', amount: 1200.00, currency: 'EUR' },
+    { type: 'vente', date: '2025-02-28', account_code: '706',  designation: 'Loyer février',             tier: 'Locataire Dupont', amount: 1200.00, currency: 'EUR' },
+    { type: 'vente', date: '2025-03-31', account_code: '709',  designation: 'Remise commerciale',        tier: 'Locataire Dupont', amount: -50.00,  currency: 'EUR' },
+    // 2024 tests
+    { type: 'vente', date: '2024-12-31', account_code: '706',  designation: 'Loyer décembre',            tier: 'Locataire Durand', amount: 1200.00, currency: 'EUR' },
+    { type: 'achat', date: '2024-11-15', account_code: '606',  designation: 'Fournitures ménage',        tier: 'Fournisseur ABC',  amount: 90.00,  currency: 'EUR' },
+  ];
+  const assets: SeedAssetBase[] = [
+    { label: 'Mobil-home',     amount_ht: 20000.00, duration_years: 10, acquisition_date: '2024-04-01', account_code: '2183' },
+    { label: 'Électroménager', amount_ht: 3000.00,  duration_years: 3,  acquisition_date: '2025-01-15', account_code: '2155' },
+  ];
+  return { journal, assets };
+}
+


### PR DESCRIPTION
Résumé: Ajout d’un seed de démonstration couvrant écritures Achats/Ventes (2024–2025) et deux immobilisations pour tester 2033C, 2033E et 2033A. Les données sont taguées via le suffixe “ [seed]” pour permettre un unseed sélectif. Opérations idempotentes (réexécutions sans doublons) + script d’unseed correspondant.
Détails:
scripts/dbSeedDemo.ts: création/upsert admin + upsert journal_entries & assets (suffixe [seed]); support DRY_RUN=1.
scripts/dbUnseedDemo.ts: suppression des entrées/immobilisations suffixées.
src/lib/seedDemoCore.ts (+ test): définition centralisée des données seed.
package.json: scripts db:seed:demo / db:unseed:demo + dépendance tsx.
README: section “Seed de démo” (commandes, scénarios de test).
Tests: seedDemoCore.test (montants clés vérifiés).
Jeu de données: Achats 2025: 606 (350), 6063 (180), 615 (240), 616 (120), 62 (300), 627 (12.50), 635 (400)
Ventes 2025: 706 (1200 + 1200), 709 (-50)
2024: Vente 706 (1200), Achat 606 (90)
Immobilisations: Mobil-home (20 000 /10 ans – 2024-04-01), Électroménager (3 000 /3 ans – 2025-01-15)
Utilisation: pnpm db:seed:demo
pnpm db:unseed:demo
DRY_RUN=1 pnpm db:seed:demo (simulation)
Contrôles recommandés:
/journal/achats?from=2025-01-01&to=2025-12-31
/reports/2033c?from=2025-01-01&to=2025-12-31
/reports/2033e?year=2025
/reports/2033a?year=2025
Points de revue:
Nommage / libellés des écritures et assets
Suffixe “[seed]” acceptable ou préférer un champ meta ultérieur
Couverture fonctionnelle suffisante pour démo rapports